### PR TITLE
Fix compatibility issue with multilevel tokens

### DIFF
--- a/scripts/token-mold.js
+++ b/scripts/token-mold.js
@@ -245,7 +245,7 @@ export default class TokenMold {
     _setTokenData(scene, data) {
         const actor = game.actors.get(data.actorId);
 
-        if (data.actorLink && this.data.unlinkedOnly) // Don't for linked token
+        if (!actor || (data.actorLink && this.data.unlinkedOnly)) // Don't for linked token
             return data;
 
         // Do this for all tokens, even player created ones


### PR DESCRIPTION
Fix issues some users are having with the cloned tokens created by Multilevel Tokens which have actor set to "None", see https://github.com/grandseiken/foundryvtt-multilevel-tokens/issues/14