### PR TITLE
Corrected "compatible core version"

### DIFF
--- a/module.json
+++ b/module.json
@@ -16,7 +16,7 @@
   "flags": {},
   "version": "2.14.0",
   "minimumCoreVersion": "0.8.4",
-  "compatibleCoreVersion": "9.233",
+  "compatibleCoreVersion": "9",
   "scripts": [],
   "esmodules": ["scripts/index.js"],
   "styles": ["token-mold.css"],


### PR DESCRIPTION
In foundry V9 the build number does not have to be specified. After this change the "compatibility risk" warning disappears in Foundry V9