### PR TITLE
Add logic to allow Token Mold to change a name to a prefix

### DIFF
--- a/lang/cn.json
+++ b/lang/cn.json
@@ -35,6 +35,7 @@
   "tmold.name.baseNameNothing": "不动",
   "tmold.name.baseNameRemove": "消除",
   "tmold.name.baseNameReplace": "替换为随机的名称",
+  "tmold.name.baseNamePrefix": "替换为演员姓名的前 2 个字母",
   "tmold.name.baseNameOverride": "Hold Shift to override name removal or replacement and always add the base name",
   "tmold.name.replaceHelp": "有关该功能如何工作的更多信息，请查看模块主页。",
   "tmold.name.replaceInfo1": "所选选项将用生成的名称替换指示物的基础名称。",

--- a/lang/de.json
+++ b/lang/de.json
@@ -35,6 +35,7 @@
   "tmold.name.baseNameNothing": "Nichts tun",
   "tmold.name.baseNameRemove": "Entfernen",
   "tmold.name.baseNameReplace": "Durch zufälligen Namen ersetzen",
+  "tmold.name.baseNamePrefix": "Ersetzen Sie den Namen des Schauspielers durch die ersten 2 Buchstaben",
   "tmold.name.baseNameOverride": "Hold Shift to override name removal or replacement and always add the base name",
   "tmold.name.replaceHelp": "Für weitere Informationen wie das Funktioniert, kannst du auf der Modul Homepage schauen.",
   "tmold.name.replaceInfo1": "Die ausgewählte Option wird den Namen der Figur mit einem generierten ersetzen.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -38,6 +38,7 @@
   "tmold.name.baseNameNothing": "Do nothing",
   "tmold.name.baseNameRemove": "Remove",
   "tmold.name.baseNameReplace": "Replace with randomized name",
+  "tmold.name.baseNamePrefix": "Replace with first 2 letters of actor's name",
   "tmold.name.baseNameOverride": "Hold Shift to override name removal or replacement and always add the base name",
   "tmold.name.replaceHelp": "For more information on how this works look onto the modules homepage.",
   "tmold.name.replaceInfo1": "The chosen option will replace the tokens base name with a generated name.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -36,6 +36,7 @@
   "tmold.name.baseNameNothing": "No hacer nada",
   "tmold.name.baseNameRemove": "Quitar",
   "tmold.name.baseNameReplace": "Reemplazar con un nombre al azar",
+  "tmold.name.baseNamePrefix": "Reemplazar con las primeras 2 letras del nombre del actor",
   "tmold.name.replaceHelp": "Más información en cómo funciona en la página del módulo",
   "tmold.name.replaceInfo1": "Lo que se elija reemplazará el nombre base del icono con uno generado",
   "tmold.name.replaceInfo2": "Puede elegir una serie de atributos. Para cada atributo podrá escoger entre los valores posibles y asignarles un idioma. Al crear el icono se escogerá el primer valor válido. Si no hay ninguno, se usarán los valores por defecto",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -35,6 +35,7 @@
     "tmold.name.baseNameNothing": "何もしない",
     "tmold.name.baseNameRemove": "削除する",
     "tmold.name.baseNameReplace": "ランダムな名前に置き換える",
+    "tmold.name.baseNamePrefix": "俳優名の最初の2文字に置き換えます",
     "tmold.name.replaceHelp": "これがどのように機能するか？ 詳細については､モジュールのホームページをご覧ください。",
     "tmold.name.replaceInfo1": "選択したオプションにより､トークンの元々の名前が自動生成された名前に置き換えられます。",
     "tmold.name.replaceInfo2": "いくつかの特性を選択できます。特性ごとに､可能な値を選択して言語に割り当てることができます。トークンの作成時に適合する最初の値が選択されます。適切な値が見つからなかった場合､デフォルトが使用されます。",

--- a/scripts/token-mold.js
+++ b/scripts/token-mold.js
@@ -407,7 +407,7 @@ export default class TokenMold {
     }
 
     if ("prefix" === this.data.name.replace && !(this.data.name.baseNameOverride && event.getModifierState("Shift"))) {
-      name = name.substring(0, 2);
+      name = name.substring(0, 2).toUpperCase();
     }
 
     let numberSuffix = "";

--- a/scripts/token-mold.js
+++ b/scripts/token-mold.js
@@ -406,6 +406,10 @@ export default class TokenMold {
       name = "";
     }
 
+    if ("prefix" === this.data.name.replace && !(this.data.name.baseNameOverride && event.getModifierState("Shift"))) {
+      name = name.substring(0, 2);
+    }
+
     let numberSuffix = "";
     if (this.data.name.number.use) {
       let number = 0;

--- a/templates/token-mold.html
+++ b/templates/token-mold.html
@@ -77,6 +77,7 @@
                 <option value="nothing">{{ localize "tmold.name.baseNameNothing" }}</option>
                     <option value="remove">{{ localize "tmold.name.baseNameRemove" }}</option>
                     <option value="replace">{{ localize "tmold.name.baseNameReplace" }}</option>
+                    <option value="prefix">{{ localize "tmold.name.baseNamePrefix" }}</option>
                 {{/select}}
             </select>
         </div>


### PR DESCRIPTION
This will match the naming logic used by Avrae for adding monsters to combat for play-by-post games, making it easy for players to see which monster is which without the DM manually fixing each token. 