### PR TITLE
Update to V11 style data (Deprecated)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,30 +12,49 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        # https://github.com/marketplace/actions/checkout
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v4
       - name: Get version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/*/}
+        run: echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: Zip files
         run: |
           zip -r ${{ steps.get_version.outputs.VERSION }}.zip *.css module.json LICENSE scripts templates assets lang
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Create and Upload Release
+        # https://github.com/marketplace/actions/gh-release
+        # https://github.com/softprops/action-gh-release
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ steps.get_version.outputs.VERSION }}.zip
-          asset_name: ${{ steps.get_version.outputs.VERSION }}.zip
-          asset_content_type: application/zip
+          files: ${{ steps.get_version.outputs.VERSION }}.zip
+
+      # - name: Create Release
+      #   id: create_release
+      #   # https://github.com/actions/create-release
+      #   # unmaintained
+      #   uses: actions/create-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     tag_name: ${{ github.ref }}
+      #     release_name: Release ${{ github.ref }}
+      #     draft: false
+      #     prerelease: false
+      # - name: Upload Release Asset
+      #   id: upload-release-asset
+      #   # https://github.com/actions/upload-release-asset
+      #   # unmaintained
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_path: ./${{ steps.get_version.outputs.VERSION }}.zip
+      #     asset_name: ${{ steps.get_version.outputs.VERSION }}.zip
+      #     asset_content_type: application/zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
+# v2.22.0
+- Updated to support Foundry v12
+   - NOTE: Due to V12 no longer supporing synchronous dice rolling HP are now set post token creation. That means you'll see the HP change displayed briefly (a small number with the delta will float over the token for a moment).
+- The code for the adjective table has been simplified. That might mean the table you previously select to choose adjectives from got reset.
+
 # v2.21.0
 - Updated to support DnD5e 3.x and Foundry v11
 - Dropped support for Foundry V9 and V10
 
 # v2.20.3
  - Corrected bug that prevented refresh tokens from functioning ( [[#181](https://github.com/Moerill/token-mold/issues/181)])
- 
+
 # V2.20.2
  - Corrected bug where certain systems define types of Actors not meant to be instantiated, breaking DocumentClass reading ( [#176](https://github.com/Moerill/token-mold/issues/176) )
- 
+
 # v2.20.1
  - Corrected bug with HP not rolling correctly ( [#173](https://github.com/Moerill/token-mold/issues/173)) )
 
@@ -15,7 +20,7 @@
  - Foundry v11 Compatibility Update ( [#167](https://github.com/Moerill/token-mold/issues/167))
  - Corrected bug that caused Token Mold to conflict with other modules due to overwriting certain data within the token ([#150](https://github.com/Moerill/token-mold/issues/150))
  - Corrected issue where bar attributes were being retrieved from the base Token Document, causing a problem if that document was overriden by the system ([#160](https://github.com/Moerill/token-mold/issues/160))
- 
+
 # v2.15.4
  - Adjusted resolutions to #137 & #138
  - Corrected an issue where refreshing selected tokens was causing a circular reference error ( [#141](https://github.com/Moerill/token-mold/issues/141) ).
@@ -48,7 +53,7 @@
 - Merged Japanese localization, with thanks to BrotherSharper!
 - **Fix** Added support for Foundry v9
 - **Fix** Corrected a bug where Disposition was not properly getting saved ( Issue #60 )
-- **Fix** Corrected a bug where token scaling could be set to extremely tiny numbers in certain situations ( Issue #75 ) 
+- **Fix** Corrected a bug where token scaling could be set to extremely tiny numbers in certain situations ( Issue #75 )
 
 # v2.13.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.21.0
+- Updated to support DnD5e 3.x and Foundry v11
+- Dropped support for Foundry V9 and V10
+
 # v2.20.3
  - Corrected bug that prevented refresh tokens from functioning ( [[#181](https://github.com/Moerill/token-mold/issues/181)])
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.22.1
+- Supporting v12 required removing v11 support.
+
 # v2.22.0
 - Updated to support Foundry v12
    - NOTE: Due to V12 no longer supporing synchronous dice rolling HP are now set post token creation. That means you'll see the HP change displayed briefly (a small number with the delta will float over the token for a moment).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,8 +13,8 @@ const argv = require("yargs").argv;
 const browserSync = require("browser-sync").create();
 
 const moduleName = "token-mold";
-const repoBaseUrl = "https://github.com/Moerill/";
-const rawBaseUrl = "https://raw.githubusercontent.com/Moerill/";
+const repoBaseUrl = "https://github.com/BeardedGnome/";
+const rawBaseUrl = "https://raw.githubusercontent.com/BeardedGnome/";
 
 function getManifest() {
   const json = { root: "" };

--- a/module.json
+++ b/module.json
@@ -11,21 +11,26 @@
     {
       "name": "Geekswordsman",
       "discord": "@Geekswordsman#3085"
-    }],
+    }
+  ],
   "url": "https://github.com/Moerill/token-mold",
   "bugs": "https://github.com/Moerill/token-mold/issues",
   "flags": {},
-  "version": "2.20.3",
-  "minimumCoreVersion": "9",
+  "version": "2.21.0",
+  "minimumCoreVersion": "11",
   "compatibleCoreVersion": "11",
   "compatibility": {
-    "minimum": "9",
+    "minimum": "11",
     "verified": "11",
     "maximum": "11"
-},
-"scripts": [],
-  "esmodules": ["scripts/index.js"],
-  "styles": ["token-mold.css"],
+  },
+  "scripts": [],
+  "esmodules": [
+    "scripts/index.js"
+  ],
+  "styles": [
+    "token-mold.css"
+  ],
   "languages": [
     {
       "lang": "en",
@@ -64,11 +69,13 @@
       "private": false
     }
   ],
-  "system": [],
-  "dependencies": [],
+  "relationships": {
+    "systems": [],
+    "requires": []
+  },
   "socket": false,
   "manifest": "https://raw.githubusercontent.com/Moerill/token-mold/master/module.json",
-  "download": "https://github.com/Moerill/token-mold/releases/download/v2.20.3/v2.20.3.zip",
+  "download": "https://github.com/Moerill/token-mold/releases/download/v2.21.0/v2.21.0.zip",
   "protected": false,
   "coreTranslation": false
 }

--- a/module.json
+++ b/module.json
@@ -1,9 +1,7 @@
 {
   "id": "token-mold",
-  "name": "token-mold",
   "title": "Token Mold",
   "description": "<p>Gives the option to cast your tokens into a mold of your choosing.</p> <p>Possible options for your mold include:</p> <ul><li>Adding incrementing number suffixes.</li><li>Name generation for tokens.</li><li>Random adjective prefixes. (Examples: angry, calm, bloodthirsty, ...)</li><li>Rolling Hit Points by formula (dnd5e only)</li><li>Set token configuration on placement.</li><li>Providing an overlay to quickly check some stats on token hover.</li><li>Automatic creature size scaling (dnd5e only)</li></ul><hr>",
-  "author": "Moerill",
   "authors": [
     {
       "name": "Moerill"
@@ -18,16 +16,12 @@
   ],
   "url": "https://github.com/Moerill/token-mold",
   "bugs": "https://github.com/Moerill/token-mold/issues",
-  "flags": {},
-  "version": "2.21.0",
-  "minimumCoreVersion": "11",
-  "compatibleCoreVersion": "11",
+  "version": "2.22.0",
   "compatibility": {
     "minimum": "11",
-    "verified": "11",
-    "maximum": "11"
+    "verified": "12",
+    "maximum": "12"
   },
-  "scripts": [],
   "esmodules": [
     "scripts/index.js"
   ],
@@ -72,13 +66,7 @@
       "private": false
     }
   ],
-  "relationships": {
-    "systems": [],
-    "requires": []
-  },
   "socket": false,
   "manifest": "https://raw.githubusercontent.com/BeardedGnome/token-mold/master/module.json",
-  "download": "https://github.com/BeardedGnome/token-mold/releases/download/v2.21.0/v2.21.0.zip",
-  "protected": false,
-  "coreTranslation": false
+  "download": "https://github.com/BeardedGnome/token-mold/releases/download/v2.22.0/v2.22.0.zip"
 }

--- a/module.json
+++ b/module.json
@@ -11,6 +11,9 @@
     {
       "name": "Geekswordsman",
       "discord": "@Geekswordsman#3085"
+    },
+    {
+      "name": "BeardedGnome"
     }
   ],
   "url": "https://github.com/Moerill/token-mold",
@@ -74,8 +77,8 @@
     "requires": []
   },
   "socket": false,
-  "manifest": "https://raw.githubusercontent.com/Moerill/token-mold/master/module.json",
-  "download": "https://github.com/Moerill/token-mold/releases/download/v2.21.0/v2.21.0.zip",
+  "manifest": "https://raw.githubusercontent.com/BeardedGnome/token-mold/master/module.json",
+  "download": "https://github.com/BeardedGnome/token-mold/releases/download/v2.21.0/v2.21.0.zip",
   "protected": false,
   "coreTranslation": false
 }

--- a/module.json
+++ b/module.json
@@ -16,9 +16,9 @@
   ],
   "url": "https://github.com/Moerill/token-mold",
   "bugs": "https://github.com/Moerill/token-mold/issues",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "compatibility": {
-    "minimum": "11",
+    "minimum": "12",
     "verified": "12",
     "maximum": "12"
   },
@@ -68,5 +68,5 @@
   ],
   "socket": false,
   "manifest": "https://raw.githubusercontent.com/BeardedGnome/token-mold/master/module.json",
-  "download": "https://github.com/BeardedGnome/token-mold/releases/download/v2.22.0/v2.22.0.zip"
+  "download": "https://github.com/BeardedGnome/token-mold/releases/download/v2.22.1/v2.22.1.zip"
 }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,18 +1,11 @@
 import TokenMold from "./token-mold.js";
 
 /*Enable Debug Module */
+// NOTE: Developer Mode doesn't work in Foundry v12
 Hooks.once('devModeReady', ({ registerPackageDebugFlag }) => {
   registerPackageDebugFlag(TokenMold.MODULEID);
 });
 
-Hooks.on("init", () => {
+Hooks.once("init", () => {
   game["token-mold"] = new TokenMold();
 });
-
-// import Mold from './mold.js';
-// import MoldConfig from './settings.js';
-
-// Hooks.on('setup', () => {
-//   Mold.init();
-// 	MoldConfig.init();
-// });

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -1,9 +1,6 @@
 export class TokenMoldOverlay extends BasePlaceableHUD {
-  static FOUNDRY_VERSION = 0;
 
   static get defaultOptions() {
-    TokenMoldOverlay.FOUNDRY_VERSION = game.version ?? game.data.version;
-
     const options = super.defaultOptions;
     options.classes = options.classes.concat(["token-mold-overlay"]);
     options.template = "modules/token-mold/templates/overlay.html";
@@ -19,7 +16,7 @@ export class TokenMoldOverlay extends BasePlaceableHUD {
         const ret = {
           icon: e.icon,
           path: e.path,
-          value: getProperty(this.object.actor, e.path),
+          value: foundry.utils.getProperty(this.object.actor, e.path),
         };
         if (ret.value === "" || ret.value === null || ret.value === undefined)
           return null;

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -1,42 +1,44 @@
 export class TokenMoldOverlay extends BasePlaceableHUD {
-	static FOUNDRY_VERSION = 0;
+  static FOUNDRY_VERSION = 0;
 
-	static get defaultOptions() {
-		TokenMoldOverlay.FOUNDRY_VERSION = game.version ?? game.data.version;
+  static get defaultOptions() {
+    TokenMoldOverlay.FOUNDRY_VERSION = game.version ?? game.data.version;
 
-		const options = super.defaultOptions;
-		options.classes = options.classes.concat(["token-mold-overlay"]);
-		options.template = "modules/token-mold/templates/overlay.html";
-		options.id = "token-mold-overlay";
-		return options;
-	}
+    const options = super.defaultOptions;
+    options.classes = options.classes.concat(["token-mold-overlay"]);
+    options.template = "modules/token-mold/templates/overlay.html";
+    options.id = "token-mold-overlay";
+    return options;
+  }
 
-	getData() {
-		const data = super.getData();
-		// get properties and filter if property was not found
-		data.stats = this.attrs.map(e => {
-			const ret =  {
-				icon: e.icon,
-				path: e.path,
-				value: TokenMoldOverlay.FOUNDRY_VERSION >= 10 ? getProperty(this.object.actor, e.path) : getProperty(this.object.actor.data, e.path)
-			};
-			if (ret.value === ""  || ret.value === null || ret.value === undefined)
-				return null;
-			return ret;
-		}).filter(e => e !== null);
-		return data;
-	}
+  getData() {
+    const data = super.getData();
+    // get properties and filter if property was not found
+    data.stats = this.attrs
+      .map((e) => {
+        const ret = {
+          icon: e.icon,
+          path: e.path,
+          value: getProperty(this.object.actor, e.path),
+        };
+        if (ret.value === "" || ret.value === null || ret.value === undefined)
+          return null;
+        return ret;
+      })
+      .filter((e) => e !== null);
+    return data;
+  }
 
-	setPosition() {
-		if (!this.object) return;
+  setPosition() {
+    if (!this.object) return;
 
-	  const position = {
-	    width: this.object.w,
+    const position = {
+      width: this.object.w,
       height: this.object.h,
       left: this.object.x,
-			top: this.object.y,
-			"font-size": canvas.grid.size / 5 + "px"
+      top: this.object.y,
+      "font-size": canvas.grid.size / 5 + "px",
     };
-		this.element.css(position);
+    this.element.css(position);
   }
 }

--- a/scripts/token-mold.js
+++ b/scripts/token-mold.js
@@ -1,28 +1,32 @@
 import { TokenMoldOverlay } from "./overlay.js";
 export default class TokenMold {
   static MODULEID = "token-mold";
-  static FOUNDRY_VERSION = 0;
-  static GAME_SYSTEM = null;
-  static LOG_LEVEL = {
+  static LOG_LEVEL = Object.freeze({
     Debug: 0,
     Info: 1,
     Warn: 2,
     Error: 3,
-  };
+  });
+  static CURRENT_LOG_LEVEL = TokenMold.LOG_LEVEL.Info;
+
+  static SUPPORTED_SYSTEMS = ["dnd5e", "pf2e", "sfrpg", "sw5e", "dcc"];
+  static SUPPORTED_ROLLHP = ["dnd5e", "sw5e", "dcc"];
+  static SUPPORTED_CREATURESIZE = ["dnd5e", "pf2e"];
+  static SUPPORTED_5ESKILLS = ["dnd5e", "sw5e"];
 
   constructor() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "TokenMold");
     this.counter = {};
     this._rollTableList = {};
     this.dict = null;
 
-    TokenMold.FOUNDRY_VERSION = game.version ?? game.data.version;
-
     this.initHooks();
   }
 
-  static log(force, level, ...args) {
+  static log(level, ...args) {
+    // NOTE: Developer Mode doesn't work in Foundry v12
     const shouldLog =
-      force ||
+      level >= TokenMold.CURRENT_LOG_LEVEL ||
       game.modules
         .get("_dev-mode")
         ?.api?.getPackageDebugValue(TokenMold.MODULEID);
@@ -47,15 +51,14 @@ export default class TokenMold {
   }
 
   initHooks() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "initHooks");
     Hooks.on("renderActorDirectory", (app, html, data) => {
       if (game.user.isGM) {
         this._hookActorDirectory(html);
       }
     });
 
-    TokenMold.GAME_SYSTEM = game.system?.id ?? game.data.system.id;
-    this.systemSupported =
-      /dnd5e|pf2e|sfrpg|sw5e|dcc/.exec(TokenMold.GAME_SYSTEM) !== null;
+    this.systemSupported = TokenMold.SUPPORTED_SYSTEMS.includes(game.system.id);
 
     this.registerSettings();
     this.loadSettings();
@@ -66,15 +69,11 @@ export default class TokenMold {
       }
 
       // Don't show for permission lvl lower than observer
-      if (token.actor.permission < CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER) {
+      if (token.actor.permission < CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER) {
         return;
       }
 
-      if (
-        canvas.hud.TokenMold === undefined ||
-        this.data.overlay.attrs.length === 0 ||
-        (token.document.actorLink && !this.data.enableOverlayForLinked)
-      ) {
+      if (canvas.hud.TokenMold === undefined || this.data.overlay.attrs.length === 0 || (token.document.actorLink && !this.data.enableOverlayForLinked)) {
         return;
       }
 
@@ -86,8 +85,8 @@ export default class TokenMold {
       }
     });
 
-    Hooks.on("ready", async () => {
-      Hooks.on("renderHeadsUpDisplay", async (app, html, data) => {
+    Hooks.once("ready", async () => {
+      Hooks.on("renderHeadsUpDisplay", (app, html, data) => {
         html.append('<template id="token-mold-overlay"></template>');
         canvas.hud.TokenMold = new TokenMoldOverlay();
       });
@@ -96,14 +95,29 @@ export default class TokenMold {
         return;
       }
 
-      Hooks.on("deleteToken", (...args) => {
+      Hooks.on("deleteToken", (token, options, userId) => {
         if (!canvas.hud.TokenMold) return;
         canvas.hud.TokenMold.clear();
       });
 
-      this._hookPreTokenCreate();
+      Hooks.on("preCreateToken", (token, data, options, userId) => {
+        const scene = token.parent;
+        const newData = this._setTokenData(scene, data);
+        TokenMold.log(TokenMold.LOG_LEVEL.Debug, "preCreateToken", token, data, newData, );
+        token.updateSource(newData);
+      });
+
+      Hooks.on("createToken", (token, options, userId) => {
+        if (userId !== game.userId) {
+          // filter to single user
+          return;
+        }
+        TokenMold.log(TokenMold.LOG_LEVEL.Debug, "createToken", token, );
+        this._setHP(token);
+      });
+
       this.barAttributes = await this._getBarAttributes();
-      this._loadDicts();
+      await this._loadDicts();
 
       await this._getRolltables();
 
@@ -112,6 +126,7 @@ export default class TokenMold {
   }
 
   get languages() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "languages");
     return [
       "afrikaans",
       "albanian",
@@ -156,6 +171,7 @@ export default class TokenMold {
    * possible TODO: maybe check if dict is needed?
    */
   async _loadDicts() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_loadDicts");
     // Remove if replace is unset
     if (!game.user || !game.user.isGM || this.data.name.replace !== "replace") {
       // Useful to free up memory? its "just" up to 17MB...
@@ -175,6 +191,7 @@ export default class TokenMold {
   }
 
   async _loadTable() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_loadTable");
     let document;
     try {
       document = await fromUuid(this.data.name.prefix.table);
@@ -189,9 +206,8 @@ export default class TokenMold {
 
   // Gets a list of all Rollable Tables available to choose adjectives from.
   async _getRolltables() {
-    const rollTablePacks = game.packs.filter(
-      (e) => e.documentName === "RollTable",
-    );
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_getRolltables");
+    const rollTablePacks = game.packs.filter((e) => e.documentName === "RollTable", );
 
     this._rollTableList = {};
     if (game.tables.size > 0) {
@@ -204,26 +220,19 @@ export default class TokenMold {
       });
     }
     for (const pack of rollTablePacks) {
-      const idx = await pack.getIndex();
       this._rollTableList[pack.metadata.label] = [];
-      const tableString = `Compendium.${pack.collection}.`;
-      for (let table of idx) {
+      for (let table of pack.index) {
         this._rollTableList[pack.metadata.label].push({
           name: table.name,
-          uuid: tableString + table._id,
+          uuid: table.uuid,
         });
       }
     }
-
-    TokenMold.log(
-      false,
-      TokenMold.LOG_LEVEL.Debug,
-      "Rollable Tables found",
-      this._rollTableList,
-    );
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "Rollable Tables found", this._rollTableList,);
   }
 
   async _hookActorDirectory(html) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_hookActorDirectory");
     this.section = document.createElement("section");
     this.section.classList.add("token-mold");
     // Add menu before directory header
@@ -236,6 +245,7 @@ export default class TokenMold {
   }
 
   async _renderActorDirectoryMenu() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_renderActorDirectoryMenu");
     const section = this.section;
     section.insertAdjacentHTML(
       "afterbegin",
@@ -245,7 +255,7 @@ export default class TokenMold {
             <input class='name rollable' type='checkbox' name='name.use' ${this.data.name.use ? "checked" : ""}><span><span class='checkmark'></span>&nbsp;Name</span>
         </label>
         ${
-          ["dnd5e", "dcc", "sw5e"].includes(TokenMold.GAME_SYSTEM)
+          TokenMold.SUPPORTED_ROLLHP.includes(game.system.id)
             ? `
         <label class='label-inp' title='(De-)activate Hit Point rolling'>
             <input class='hp rollable' type='checkbox' name='hp.use' ${this.data.hp.use ? "checked" : ""}><span><span class='checkmark'></span>&nbsp;HP</span>
@@ -268,7 +278,7 @@ export default class TokenMold {
     const inputs = section.querySelectorAll('input[type="checkbox"]');
     for (let checkbox of inputs) {
       checkbox.addEventListener("change", (ev) => {
-        setProperty(this.data, ev.target.name, ev.target.checked);
+        foundry.utils.setProperty(this.data, ev.target.name, ev.target.checked);
         this.saveSettings();
       });
     }
@@ -294,26 +304,11 @@ export default class TokenMold {
    *  - Popout sidebar needs to update on change as well
    */
   _updateCheckboxes() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_updateCheckboxes");
     const inputs = document.querySelectorAll("section.token-mold input");
     inputs.forEach((el) => {
       const name = el.name;
-      el.checked = getProperty(this.data, name);
-    });
-  }
-
-  _hookPreTokenCreate() {
-    Hooks.on("preCreateToken", (token, data, options, userId) => {
-      const scene = token.parent;
-      const newData = this._setTokenData(scene, data);
-      TokenMold.log(
-        false,
-        TokenMold.LOG_LEVEL.Debug,
-        "preCreateToken",
-        token,
-        data,
-        newData,
-      );
-      token.updateSource(newData);
+      el.checked = foundry.utils.getProperty(this.data, name);
     });
   }
 
@@ -323,6 +318,7 @@ export default class TokenMold {
    * @param {*} data TokenData
    */
   _setTokenData(scene, data) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_setTokenData");
     const actor = game.actors.get(data.actorId);
     const newData = { _id: data._id };
 
@@ -332,10 +328,7 @@ export default class TokenMold {
     }
 
     // Do this for all tokens, even player created ones
-    if (
-      this.data.size.use &&
-      /dnd5e|pf2e/.exec(TokenMold.GAME_SYSTEM) !== null
-    ) {
+    if (this.data.size.use && TokenMold.SUPPORTED_CREATURESIZE.includes(game.system.id)) {
       this._setCreatureSize(newData, data, actor, scene.id);
     }
 
@@ -346,13 +339,7 @@ export default class TokenMold {
     if (this.data.name.use) {
       const newName = this._modifyName(newData, data, actor, scene.id);
       newData.name = newName;
-      setProperty(newData, "delta.name", newName);
-    }
-
-    if (/dnd5e|dcc/.exec(TokenMold.GAME_SYSTEM) !== null) {
-      if (this.data.hp.use) {
-        this._rollHP(newData, data, actor);
-      }
+      foundry.utils.setProperty(newData, "delta.name", newName);
     }
 
     if (this.data.config.use) {
@@ -362,17 +349,57 @@ export default class TokenMold {
     return newData;
   }
 
+  async _setHP(token) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_setHP");
+
+    if (!token.actor || (token.actorLink && this.data.unlinkedOnly)) {
+      // Don't for linked token
+      return;
+    }
+
+    if (TokenMold.SUPPORTED_ROLLHP.includes(game.system.id)) {
+      if (this.data.hp.use) {
+        const val = await this._rollHP(token);
+        token.actor.update({'system.attributes.hp': {value: val, max: val}});
+      }
+    }
+  }
+
+  // Probably not required, but I implemented it before I understood
+  async _setDeltaHP(token, data) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_setDeltaHP");
+
+    if (!token.actor || (token.actorLink && this.data.unlinkedOnly)) {
+      // Don't for linked token
+      return;
+    }
+
+    if (TokenMold.SUPPORTED_ROLLHP.includes(game.system.id)) {
+      if (this.data.hp.use) {
+        const val = await this._rollHP(token);
+        foundry.utils.setProperty(data, "delta.system.attributes.hp.value", val);
+        foundry.utils.setProperty(data, "delta.system.attributes.hp.max", val);
+      }
+    }
+  }
+
   async _refreshSelected() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_refreshSelected");
     const selected = canvas.tokens.controlled;
     let udata = [];
     for (const token of selected) {
-      udata.push(this._setTokenData(canvas.scene, token.document.toObject()));
+      const newData = this._setTokenData(canvas.scene, token.document.toObject());
+
+      await this._setDeltaHP(token.document, newData);
+
+      udata.push(newData);
     }
 
     canvas.scene.updateEmbeddedDocuments("Token", udata);
   }
 
   _overwriteConfig(data, actor) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_overwriteConfig");
     for (let [key, value] of Object.entries(this.data.config)) {
       if (value.use !== true) {
         continue;
@@ -381,64 +408,61 @@ export default class TokenMold {
         data[key] = value.value;
       } else if (value.min !== undefined && value.max !== undefined) {
         let val = data[key] || 1;
-        data[key] =
-          (val *
-            Math.floor(
-              (Math.random() * (value.max - value.min) + value.min) * 100,
-            )) /
-          100;
-      } else if (
-        value.attribute !== undefined &&
-        (value.attribute === "" ||
-          getProperty(actor, value.attribute) !== undefined)
-      ) {
+        data[key] = (val * Math.floor((Math.random() * (value.max - value.min) + value.min) * 100, )) / 100;
+      } else if (value.attribute !== undefined && (value.attribute === "" || foundry.utils.getProperty(actor, value.attribute) !== undefined) ) {
         data[key].attribute = value.attribute;
-      } else if (
-        value.attribute === undefined &&
-        value.min === undefined &&
-        value.max === undefined &&
-        value.value === undefined
-      ) {
+      } else if ( value.attribute === undefined && value.min === undefined && value.max === undefined && value.value === undefined ) {
         // Random mirroring
         data[key] = Boolean(Math.round(Math.random()));
       }
     }
   }
 
-  _rollHP(newData, data, actor) {
+  async _rollHP(token) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_rollHP");
     const hpProperties = {
       dnd5e: "system.attributes.hp.formula",
+      sw5e: "system.attributes.hp.formula",
       dcc: "system.attributes.hitDice.value",
     };
 
-    const formula = getProperty(actor, hpProperties[TokenMold.GAME_SYSTEM]);
+    const formula = foundry.utils.getProperty(token.actor, hpProperties[game.system.id]);
     if (formula) {
-      const r = new Roll(formula.replace(" ", ""));
-      r.roll({ async: false });
+      TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_rollHP.formula", formula );
+
+      const constant = new Roll(formula.replace(" ", ""));
+      constant.evaluateSync({strict: false}); // calculate the constant portion
+      TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_rollHP.constant.evaluateSync.total", constant.total );
+
+      const roll = new Roll(formula.replace(" ", ""));
+      await roll.evaluate();
+      TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_rollHP.roll.evaluate.total", roll.total );
+
       if (this.data.hp.toChat) {
-        r.toMessage({
+        roll.toMessage({
           rollMode: "gmroll",
-          flavor: data.name + " rolls for hp!",
+          flavor: token.name + " rolls for hp!",
         });
       }
-      // Make sure hp is at least 1
-      const val = Math.max(r.total, 1);
+      // Make sure hp is at least 1 or the number of dice + constant value
+      const min = Math.max(roll.dice[0].number + constant.total, 1);
+      TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_rollHP.min", min );
+      const val = Math.max(roll.total, min);
 
-      setProperty(newData, "delta.system.attributes.hp.value", val);
-      setProperty(newData, "delta.system.attributes.hp.max", val);
+      //token.actor.update({'system.attributes.hp': {value: val, max: val}});
+      return val;
     } else {
       ui.notifications.warn("Can not randomize hp. HP formula is not set.");
+      return system.attributes.hp.value;
     }
     return;
   }
 
   _modifyName(newData, data, actor, sceneId) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_modifyName");
     let name = actor.prototypeToken.name;
 
-    if (
-      ["remove", "replace"].includes(this.data.name.replace) &&
-      !(this.data.name.baseNameOverride && event.getModifierState("Shift"))
-    ) {
+    if (["remove", "replace"].includes(this.data.name.replace) && !(this.data.name.baseNameOverride && event.getModifierState("Shift"))) {
       name = "";
     }
 
@@ -531,6 +555,7 @@ export default class TokenMold {
   }
 
   _chooseWeighted(items) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_chooseWeighted");
     var keys = Object.keys(items);
     var vals = Object.values(items);
     var sum = vals.reduce((accum, elem) => accum + elem, 0);
@@ -541,6 +566,7 @@ export default class TokenMold {
   }
 
   _chgCase(txt, fromCase, toCase) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_chgCase");
     var res = "";
     var c = "";
     for (c of txt) {
@@ -563,14 +589,13 @@ export default class TokenMold {
    * @param {*} actor
    */
   _pickNewName(actor) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_pickNewName");
     const attributes = this.data.name.options.attributes || [];
 
     let lang;
     for (let attribute of attributes) {
       const langs = attribute.languages;
-      const val = String(
-        getProperty(actor.system, attribute.attribute),
-      ).toLowerCase();
+      const val = String(foundry.utils.getProperty(actor.system, attribute.attribute), ).toLowerCase();
 
       lang = langs[val];
 
@@ -611,17 +636,12 @@ export default class TokenMold {
       newName = newName + this._chooseWeighted(c3);
     }
 
-    newName =
-      newName[0] +
-      this._chgCase(
-        newName.slice(1),
-        this.dict[lang].upper,
-        this.dict[lang].lower,
-      );
+    newName = newName[0] + this._chgCase(newName.slice(1), this.dict[lang].upper, this.dict[lang].lower, );
     return newName;
   }
 
   _dealphabetize(num, letterStyle) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_dealphabetize");
     if (num === "0") {
       return 0;
     }
@@ -639,6 +659,7 @@ export default class TokenMold {
   }
 
   _alphabetize(num, letterStyle) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_alphabetize");
     let ret = "";
 
     const startValue = {
@@ -658,6 +679,7 @@ export default class TokenMold {
 
   // Romanizes a number, code is from : http://blog.stevenlevithan.com/archives/javascript-roman-numeral-converter
   _romanize(num) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_romanize");
     if (!+num) {
       return false;
     }
@@ -704,6 +726,7 @@ export default class TokenMold {
 
   // code is from : http://blog.stevenlevithan.com/archives/javascript-roman-numeral-converter
   _deromanize(rom) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_deromanize");
     if (typeof rom !== "string") {
       return 0;
     }
@@ -739,6 +762,7 @@ export default class TokenMold {
   // Scale tokens according to set creature size
   // DnD 5e and PF2e only
   _setCreatureSize(newData, data, actor, sceneId) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_setCreatureSize");
     const sizes = {
       tiny: 0.5,
       sm: 0.8,
@@ -781,6 +805,7 @@ export default class TokenMold {
   }
 
   registerSettings() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "registerSettings");
     // register settings
     game.settings.register("Token-Mold", "everyone", {
       name: "Token Mold Settings",
@@ -796,7 +821,7 @@ export default class TokenMold {
   }
 
   defaultSettings() {
-    TokenMold.log(true, TokenMold.LOG_LEVEL.Info, "Loading default Settings");
+    TokenMold.log(TokenMold.LOG_LEVEL.Info, "Loading defaultSettings");
     return {
       unlinkedOnly: true,
       name: {
@@ -811,7 +836,7 @@ export default class TokenMold {
         prefix: {
           use: true,
           position: "front",
-          table: "Compendium.token-mold.adjectives.BGNM2VPUyFfA5ZMJ", // English
+          table: "Compendium.token-mold.adjectives.RollTable.BGNM2VPUyFfA5ZMJ", // English
         },
         replace: "",
         options: {
@@ -885,6 +910,7 @@ export default class TokenMold {
   }
 
   loadSettings() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "loadSettings");
     this.data = game.settings.get("Token-Mold", "everyone");
     // Check for old data
     if (!this.data) {
@@ -899,21 +925,15 @@ export default class TokenMold {
       }
       delete this.data.config.data;
     }
-    if (
-      getProperty(this.data, "overlay.attrs") &&
-      this.data.overlay.attrs.length === 0
-    ) {
+    if (foundry.utils.getProperty(this.data, "overlay.attrs") && this.data.overlay.attrs.length === 0) {
       delete this.data.overlay.attrs;
     }
-    if (
-      getProperty(this.data, "name.options.attributes") &&
-      this.data.name.options.attributes.length === 0
-    ) {
+    if (foundry.utils.getProperty(this.data, "name.options.attributes") && this.data.name.options.attributes.length === 0) {
       delete this.data.name.options.attributes;
     }
-    this.data = mergeObject(this.defaultSettings(), this.data);
+    this.data = foundry.utils.mergeObject(this.defaultSettings(), this.data);
 
-    if (/dnd5e|sw5e/.exec(TokenMold.GAME_SYSTEM) !== null) {
+    if (TokenMold.SUPPORTED_5ESKILLS.includes(game.system.id)) {
       if (this.data.name.options === undefined) {
         const dndOptions = this.dndDefaultNameOptions;
         this.data.name.options.default = dndOptions.default;
@@ -921,15 +941,11 @@ export default class TokenMold {
       }
     }
     this._loadDicts();
-    TokenMold.log(
-      false,
-      TokenMold.LOG_LEVEL.Debug,
-      "Loading Settings",
-      this.data,
-    );
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "Loading Settings", this.data, );
   }
 
   get dndDefaultNameOptions() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "dndDefaultNameOptions");
     return {
       default: "random",
       attributes: [
@@ -982,38 +998,24 @@ export default class TokenMold {
   }
 
   async saveSettings() {
-    if (
-      !this.adjectives ||
-      this.adjectives.uuid !== this.data.name.prefix.table
-    ) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "saveSettings");
+    if (this.adjectives || this.adjectives.uuid !== this.data.name.prefix.table) {
       this._loadTable();
     }
 
-    if (
-      this.data.name.replace === "remove" &&
-      !this.data.name.number.use &&
-      !this.data.name.prefix.use
-    ) {
+    if (this.data.name.replace === "remove" && !this.data.name.number.use && !this.data.name.prefix.use) {
       this.data.name.replace = "nothing";
-      TokenMold.log(
-        true,
-        TokenMold.LOG_LEVEL.Warn,
-        game.i18n.localize("tmold.warn.removeName"),
-      );
+      TokenMold.log(TokenMold.LOG_LEVEL.Warn, game.i18n.localize("tmold.warn.removeName"), );
       ui.notifications.warn(game.i18n.localize("tmold.warn.removeName"));
     }
 
     await game.settings.set("Token-Mold", "everyone", this.data);
     this._loadDicts();
-    TokenMold.log(
-      false,
-      TokenMold.LOG_LEVEL.Debug,
-      "Saving Settings",
-      this.data,
-    );
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "Saving Settings", this.data, );
   }
 
   async _getBarAttributes() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_getBarAttributes");
     const types = CONFIG.Actor.documentClass.TYPES;
     let barData = { bar: {}, value: {} };
     let addElement = (obj, key, val) => {
@@ -1022,6 +1024,7 @@ export default class TokenMold {
     };
     for (const type of types) {
       try {
+        // FIXME: DAE throws on 'base' type
         const docClass = new CONFIG.Actor.documentClass({
           type: type,
           name: "tmp",
@@ -1035,13 +1038,7 @@ export default class TokenMold {
           addElement(barData.value, val.join("."), type);
         }
       } catch (e) {
-        TokenMold.log(
-          false,
-          TokenMold.LOG_LEVEL.Debug,
-          "Error navigating document class type!",
-          type,
-          e,
-        );
+        TokenMold.log(TokenMold.LOG_LEVEL.Debug, "Error navigating document class type!", type, e, );
       }
     }
     return barData;
@@ -1050,12 +1047,14 @@ export default class TokenMold {
 
 class TokenMoldForm extends FormApplication {
   constructor(object, options) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "TokenMoldForm");
     super(object, options);
     this.data = object.data;
     this.barAttributes = object.barAttributes || [];
   }
 
   static get defaultOptions() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "defaultOptions");
     const options = super.defaultOptions;
     options.template = "modules/token-mold/templates/token-mold.html";
     options.width = 420;
@@ -1077,12 +1076,14 @@ class TokenMoldForm extends FormApplication {
   }
 
   _getHeaderButtons() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_getHeaderButtons");
     let btns = super._getHeaderButtons();
     btns[0].label = "Save & Close";
     return btns;
   }
 
   async _onSubmit(ev) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_onSubmit");
     const attrGroups = $(this.form).find(".attributes");
     let attrs = [];
     attrGroups.each((idx, e) => {
@@ -1120,6 +1121,7 @@ class TokenMoldForm extends FormApplication {
   }
 
   async _updateObject(event, formData) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_updateObject");
     let min = formData["name.options.min"],
       max = formData["name.options.max"];
     if (min < 0) {
@@ -1149,7 +1151,7 @@ class TokenMoldForm extends FormApplication {
         ? suffix
         : formData["name.number.suffix"];
 
-    this.object.data = mergeObject(this.data, formData);
+    this.object.data = foundry.utils.mergeObject(this.data, formData);
 
     if (this._resetOptions === true) {
       const dndOptions = this.object.dndDefaultNameOptions;
@@ -1163,6 +1165,7 @@ class TokenMoldForm extends FormApplication {
   }
 
   getData() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "getData");
     let data = {
       data: this.data,
     };
@@ -1177,24 +1180,19 @@ class TokenMoldForm extends FormApplication {
     data.displayModes = CONST.TOKEN_DISPLAY_MODES;
     data.dispositions = CONST.TOKEN_DISPOSITIONS;
     data.defaultIcons = this.defaultIcons;
-    data.showCreatureSize = /dnd5e|pf2e/.exec(game.data.system.id) !== null;
-    data.showHP = /dnd5e|dcc|sw5e/.exec(game.data.system.id) !== null;
+    data.showCreatureSize = TokenMold.SUPPORTED_CREATURESIZE.includes(game.system.id);
+    data.showHP = TokenMold.SUPPORTED_ROLLHP.includes(game.system.id);
     data.showSystem = this.object.systemSupported;
     data.languages = this.languages;
     data.rollTableList = this.object._rollTableList;
     data.visionLabel = game.i18n.localize("TOKEN.VisionEnabled");
-    TokenMold.log(
-      false,
-      TokenMold.LOG_LEVEL.Debug,
-      "Prepared data",
-      data,
-      this._rollTableList,
-    );
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "Prepared data", data, this._rollTableList, );
     return data;
   }
 
   static get defaultAttrs() {
-    if (/dnd5e|sw5e/.exec(game.data.system.id) !== null) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "defaultAttrs");
+    if (TokenMold.SUPPORTED_5ESKILLS.includes(game.system.id)) {
       return [
         {
           value: "system.attributes.ac.value",
@@ -1218,6 +1216,7 @@ class TokenMoldForm extends FormApplication {
   }
 
   get defaultIcons() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "defaultIcons");
     return [
       "&#xf06e;", // eye
       "&#xf3ed; ", //fas fa-shield-alt"></i>',
@@ -1249,10 +1248,12 @@ class TokenMoldForm extends FormApplication {
   }
 
   get languages() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "languages");
     return this.object.languages;
   }
 
   activateListeners(html) {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "activateListeners");
     super.activateListeners(html);
 
     html.find(".add-attribute").on("click", (ev) => {
@@ -1265,25 +1266,17 @@ class TokenMoldForm extends FormApplication {
     html.on("click", ".remove", (ev) => {
       const container = $(ev.currentTarget).closest(".form-group");
 
-      if (
-        container.prev('.form-group:not(".header")').length > 0 ||
-        container.next(".form-group").length > 0
-      ) {
+      if (container.prev('.form-group:not(".header")').length > 0 || container.next(".form-group").length > 0) {
         container.remove();
       }
     });
 
     html.find(".overlay").on("change keyup", "input.icon", (ev) => {
-      ev.target.parentNode.parentNode.getElementsByClassName(
-        "prev",
-      )[0].innerHTML = "17&nbsp;" + ev.target.value;
+      ev.target.parentNode.parentNode.getElementsByClassName("prev", )[0].innerHTML = "17&nbsp;" + ev.target.value;
     });
 
     html.find(".name-replace").on("change", (ev) => {
-      const nameRandomizer =
-        ev.currentTarget.parentNode.parentNode.querySelector(
-          ".name-randomizer-options",
-        );
+      const nameRandomizer = ev.currentTarget.parentNode.parentNode.querySelector(".name-randomizer-options", );
       if (ev.currentTarget.value === "replace") {
         nameRandomizer.style.display = "block";
       } else {
@@ -1326,10 +1319,7 @@ class TokenMoldForm extends FormApplication {
       } else {
         // alternatively delete whole attribute
         const parentContainer = container.closest(".attribute-group");
-        if (
-          parentContainer.prev('.attribute-group:not(".default")').length > 0 ||
-          parentContainer.next('.attribute-group:not(".default")').length > 0
-        ) {
+        if (parentContainer.prev('.attribute-group:not(".default")').length > 0 || parentContainer.next('.attribute-group:not(".default")').length > 0) {
           parentContainer.remove();
         }
       }
@@ -1352,7 +1342,7 @@ class TokenMoldForm extends FormApplication {
         udata.push({
           _id: token.id,
           name: newName,
-          "actorData.name": newName,
+          "delta.name": newName,
         });
       }
 
@@ -1376,6 +1366,7 @@ class TokenMoldForm extends FormApplication {
   }
 
   get _actorAttributes() {
+    TokenMold.log(TokenMold.LOG_LEVEL.Debug, "_actorAttributes");
     let getAttributes = function (data, parent) {
       parent = parent || [];
       let valid = [];
@@ -1393,23 +1384,20 @@ class TokenMoldForm extends FormApplication {
     let barAttributes = [];
 
     const types = Actor.implementation.TYPES;
-    const shellMap = new Map(
-      types.map((t) => [t, new Actor.implementation({ name: t, type: t })]),
-    );
+    // FIXME: DAE throws on 'base' type
+    const shellMap = new Map( types.map((t) => [t, new Actor.implementation({ name: t, type: t })]), );
     shellMap.forEach((value, key, map) => {
-      const newAttributes = getAttributes(value.toObject().system).map((e) =>
-        e.join("."),
-      );
-      // find duplicates
+      const newAttributes = getAttributes(value.toObject().system).map((e) => e.join("."), );
+      // find dups
       for (let attr of newAttributes) {
         // Search if attribute already found
-        let duplicate = barAttributes.find((el) => el[1].includes(attr));
+        let dup = barAttributes.find((el) => el[1].includes(attr));
         // If not found,  add to attributes
-        if (duplicate === undefined) {
+        if (dup === undefined) {
           barAttributes.push([key].concat(attr));
         } else {
           // if found add actor type to list
-          duplicate[0] += ", " + key;
+          dup[0] += ", " + key;
         }
       }
     });
@@ -1428,7 +1416,7 @@ class TokenMoldForm extends FormApplication {
       });
     }
     // also populate with some calculated data for dnd5e, that is not in the template.json
-    if (/dnd5e|sw5e/.exec(game.data.system.id) !== null) {
+    if (TokenMold.SUPPORTED_5ESKILLS.includes(game.system.id)) {
       let sortFun = function (a, b) {
         if (a.attribute > b.attribute) {
           return 1;

--- a/scripts/token-mold.js
+++ b/scripts/token-mold.js
@@ -1,41 +1,46 @@
 import { TokenMoldOverlay } from "./overlay.js";
 export default class TokenMold {
-  static MODULEID = 'token-mold';
+  static MODULEID = "token-mold";
   static FOUNDRY_VERSION = 0;
   static GAME_SYSTEM = null;
   static LOG_LEVEL = {
     Debug: 0,
     Info: 1,
     Warn: 2,
-    Error: 3
-  }
+    Error: 3,
+  };
 
   constructor() {
     this.counter = {};
     this._rollTableList = {};
     this.dict = null;
-    this.initHooks();
 
     TokenMold.FOUNDRY_VERSION = game.version ?? game.data.version;
+
+    this.initHooks();
   }
 
   static log(force, level, ...args) {
-    const shouldLog = force || game.modules.get('_dev-mode')?.api?.getPackageDebugValue(TokenMold.MODULEID);
+    const shouldLog =
+      force ||
+      game.modules
+        .get("_dev-mode")
+        ?.api?.getPackageDebugValue(TokenMold.MODULEID);
 
     if (shouldLog) {
       switch (level) {
         case TokenMold.LOG_LEVEL.Error:
-          console.error("Token Mold", '|', ...args);
+          console.error("Token Mold", "|", ...args);
           break;
         case TokenMold.LOG_LEVEL.Warn:
-          console.warn("Token Mold", '|', ...args);
+          console.warn("Token Mold", "|", ...args);
           break;
         case TokenMold.LOG_LEVEL.Info:
-          console.info("Token Mold", '|', ...args);
+          console.info("Token Mold", "|", ...args);
           break;
         case TokenMold.LOG_LEVEL.Debug:
         default:
-          console.debug("Token Mold", '|', ...args);
+          console.debug("Token Mold", "|", ...args);
           break;
       }
     }
@@ -43,26 +48,35 @@ export default class TokenMold {
 
   initHooks() {
     Hooks.on("renderActorDirectory", (app, html, data) => {
-      if (game.user.isGM) this._hookActorDirectory(html);
+      if (game.user.isGM) {
+        this._hookActorDirectory(html);
+      }
     });
+
+    TokenMold.GAME_SYSTEM = game.system?.id ?? game.data.system.id;
+    this.systemSupported =
+      /dnd5e|pf2e|sfrpg|sw5e|dcc/.exec(TokenMold.GAME_SYSTEM) !== null;
 
     this.registerSettings();
     this.loadSettings();
-    TokenMold.GAME_SYSTEM = game.system?.id ?? game.data.system.id;
-    this.systemSupported = /dnd5e|pf2e|sfrpg|sw5e|dcc/.exec(TokenMold.GAME_SYSTEM) !== null;
 
     Hooks.on("hoverToken", (token, hovered) => {
-      if (!token || !token.actor) return;
+      if (!token || !token.actor) {
+        return;
+      }
 
       // Don't show for permission lvl lower than observer
-      if (token.actor.permission < (TokenMold.FOUNDRY_VERSION < 9 ? CONST.ENTITY_PERMISSIONS.OBSERVER : CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER)) return;
+      if (token.actor.permission < CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER) {
+        return;
+      }
 
       if (
         canvas.hud.TokenMold === undefined ||
         this.data.overlay.attrs.length === 0 ||
         (token.document.actorLink && !this.data.enableOverlayForLinked)
-      )
+      ) {
         return;
+      }
 
       if (hovered && this.data.overlay.use === true) {
         canvas.hud.TokenMold.attrs = this.data.overlay.attrs;
@@ -78,7 +92,9 @@ export default class TokenMold {
         canvas.hud.TokenMold = new TokenMoldOverlay();
       });
 
-      if (!game.user.isGM) return;
+      if (!game.user.isGM) {
+        return;
+      }
 
       Hooks.on("deleteToken", (...args) => {
         if (!canvas.hud.TokenMold) return;
@@ -146,11 +162,14 @@ export default class TokenMold {
       // delete this.dict;
       return;
     }
-    if (!this.dict) this.dict = {};
-    const options = this.data.name.options;
+    if (!this.dict) {
+      this.dict = {};
+    }
     let languages = this.languages;
     for (let lang of languages) {
-      if (this.dict[lang]) continue;
+      if (this.dict[lang]) {
+        continue;
+      }
       this.dict[lang] = (await import(`./dict/${lang}.js`)).lang;
     }
   }
@@ -171,11 +190,13 @@ export default class TokenMold {
   // Gets a list of all Rollable Tables available to choose adjectives from.
   async _getRolltables() {
     const rollTablePacks = game.packs.filter(
-      (e) => e.documentName === "RollTable"
+      (e) => e.documentName === "RollTable",
     );
 
     this._rollTableList = {};
-    if (game.tables.size > 0) this._rollTableList["World"] = [];
+    if (game.tables.size > 0) {
+      this._rollTableList["World"] = [];
+    }
     for (const table of game.tables) {
       this._rollTableList["World"].push({
         name: table.name,
@@ -194,7 +215,12 @@ export default class TokenMold {
       }
     }
 
-    TokenMold.log(false, TokenMold.LOG_LEVEL.Debug, "Rollable Tables found", this._rollTableList);
+    TokenMold.log(
+      false,
+      TokenMold.LOG_LEVEL.Debug,
+      "Rollable Tables found",
+      this._rollTableList,
+    );
   }
 
   async _hookActorDirectory(html) {
@@ -204,7 +230,9 @@ export default class TokenMold {
     const dirHeader = html[0].querySelector(".directory-header");
     dirHeader.parentNode.insertBefore(this.section, dirHeader);
 
-    if (this.data !== undefined) this._renderActorDirectoryMenu();
+    if (this.data !== undefined) {
+      this._renderActorDirectoryMenu();
+    }
   }
 
   async _renderActorDirectoryMenu() {
@@ -214,36 +242,27 @@ export default class TokenMold {
       `
         <h3>Token Mold</h3>
         <label class='label-inp' title='(De-)activate Name randomizing'>
-            <input class='name rollable' type='checkbox' name='name.use' ${
-              this.data.name.use ? "checked" : ""
-            }><span><span class='checkmark'></span>&nbsp;Name</span>
+            <input class='name rollable' type='checkbox' name='name.use' ${this.data.name.use ? "checked" : ""}><span><span class='checkmark'></span>&nbsp;Name</span>
         </label>
         ${
-          [ "dnd5e", "dcc", "sw5e" ].includes(TokenMold.GAME_SYSTEM)
+          ["dnd5e", "dcc", "sw5e"].includes(TokenMold.GAME_SYSTEM)
             ? `
         <label class='label-inp' title='(De-)activate Hit Point rolling'>
-            <input class='hp rollable' type='checkbox' name='hp.use' ${
-              this.data.hp.use ? "checked" : ""
-            } ><span><span class='checkmark'></span>&nbsp;HP</span>
+            <input class='hp rollable' type='checkbox' name='hp.use' ${this.data.hp.use ? "checked" : ""}><span><span class='checkmark'></span>&nbsp;HP</span>
         </label>`
             : ``
         }
         <label class='label-inp' title='(De-)activate Token Config Overwrite'>
-            <input class='config rollable' type='checkbox' name='config.use' ${
-              this.data.config.use ? "checked" : ""
-            }><span><span class='checkmark'></span>&nbsp;Config</span>
+            <input class='config rollable' type='checkbox' name='config.use' ${this.data.config.use ? "checked" : ""}><span><span class='checkmark'></span>&nbsp;Config</span>
         </label>
         <label class='label-inp' title='(De-)activate Stat Overlay On Hover'>
-            <input class='config rollable' type='checkbox' name='overlay.use' ${
-              this.data.overlay.use ? "checked" : ""
-            }><span><span class='checkmark'></span>&nbsp;Overlay</span>
+            <input class='config rollable' type='checkbox' name='overlay.use' ${this.data.overlay.use ? "checked" : ""}><span><span class='checkmark'></span>&nbsp;Overlay</span>
         </label>
-
 
         <a class='refresh-selected' title="Reapplies all settings to selected tokens as if those were replaced onto the scene."><i class="fas fa-sync-alt"></i></a>
         <a class='token-rand-form-btn' title='Settings'><i class="fa fa-cog"></i></a>
         <h2></h2>
-        `
+      `,
     );
 
     const inputs = section.querySelectorAll('input[type="checkbox"]');
@@ -260,7 +279,7 @@ export default class TokenMold {
     this.section
       .querySelector(".token-rand-form-btn")
       .addEventListener("click", (ev) => {
-        if (this.form === undefined) { 
+        if (this.form === undefined) {
           this.form = new TokenMoldForm(this);
         } else {
           this.form.data = this.data;
@@ -286,12 +305,15 @@ export default class TokenMold {
     Hooks.on("preCreateToken", (token, data, options, userId) => {
       const scene = token.parent;
       const newData = this._setTokenData(scene, data);
-      TokenMold.log(false, TokenMold.LOG_LEVEL.Debug, "preCreateToken", token, data, newData);
-      if (TokenMold.FOUNDRY_VERSION >= 10) {
-        token.updateSource(newData);
-      } else {
-        token.data.update(newData);
-      }
+      TokenMold.log(
+        false,
+        TokenMold.LOG_LEVEL.Debug,
+        "preCreateToken",
+        token,
+        data,
+        newData,
+      );
+      token.updateSource(newData);
     });
   }
 
@@ -302,33 +324,40 @@ export default class TokenMold {
    */
   _setTokenData(scene, data) {
     const actor = game.actors.get(data.actorId);
-    const newData = {_id: data._id };
+    const newData = { _id: data._id };
 
-    if (!actor || (data.actorLink && this.data.unlinkedOnly))
+    if (!actor || (data.actorLink && this.data.unlinkedOnly)) {
       // Don't for linked token
       return newData;
+    }
 
     // Do this for all tokens, even player created ones
-    if (this.data.size.use && /dnd5e|pf2e/.exec(TokenMold.GAME_SYSTEM) !== null)
+    if (
+      this.data.size.use &&
+      /dnd5e|pf2e/.exec(TokenMold.GAME_SYSTEM) !== null
+    ) {
       this._setCreatureSize(newData, data, actor, scene.id);
+    }
 
-    if (this.counter[scene.id] === undefined) this.counter[scene.id] = {};
+    if (this.counter[scene.id] === undefined) {
+      this.counter[scene.id] = {};
+    }
 
     if (this.data.name.use) {
       const newName = this._modifyName(newData, data, actor, scene.id);
       newData.name = newName;
-      if (TokenMold.FOUNDRY_VERSION >= 11) {
-        setProperty(newData, "delta.name", newName);
-      } else {
-        setProperty(newData, "actorData.name", newName);
-      }
+      setProperty(newData, "delta.name", newName);
     }
 
     if (/dnd5e|dcc/.exec(TokenMold.GAME_SYSTEM) !== null) {
-      if (this.data.hp.use) this._rollHP(newData, data, actor);
+      if (this.data.hp.use) {
+        this._rollHP(newData, data, actor);
+      }
     }
 
-    if (this.data.config.use) this._overwriteConfig(newData, actor);
+    if (this.data.config.use) {
+      this._overwriteConfig(newData, actor);
+    }
 
     return newData;
   }
@@ -337,11 +366,7 @@ export default class TokenMold {
     const selected = canvas.tokens.controlled;
     let udata = [];
     for (const token of selected) {
-      if (TokenMold.FOUNDRY_VERSION >= 10) {
-        udata.push(this._setTokenData(canvas.scene, token.document.toObject()));
-      } else {
-        udata.push(this._setTokenData(canvas.scene, duplicate(token.data)));
-      }
+      udata.push(this._setTokenData(canvas.scene, token.document.toObject()));
     }
 
     canvas.scene.updateEmbeddedDocuments("Token", udata);
@@ -349,7 +374,9 @@ export default class TokenMold {
 
   _overwriteConfig(data, actor) {
     for (let [key, value] of Object.entries(this.data.config)) {
-      if (value.use !== true) continue;
+      if (value.use !== true) {
+        continue;
+      }
       if (value.value !== undefined) {
         data[key] = value.value;
       } else if (value.min !== undefined && value.max !== undefined) {
@@ -357,10 +384,14 @@ export default class TokenMold {
         data[key] =
           (val *
             Math.floor(
-              (Math.random() * (value.max - value.min) + value.min) * 100
+              (Math.random() * (value.max - value.min) + value.min) * 100,
             )) /
           100;
-      } else if (value.attribute !== undefined && (value.attribute === "" || (TokenMold.FOUNDRY_VERSION >= 10 && getProperty(actor, value.attribute) !== undefined)) || (TokenMold.FOUNDRY_VERSION < 10 && getProperty(actor, "data.data." + value.attribute) !== undefined)) {
+      } else if (
+        value.attribute !== undefined &&
+        (value.attribute === "" ||
+          getProperty(actor, value.attribute) !== undefined)
+      ) {
         data[key].attribute = value.attribute;
       } else if (
         value.attribute === undefined &&
@@ -376,33 +407,38 @@ export default class TokenMold {
 
   _rollHP(newData, data, actor) {
     const hpProperties = {
-      "dnd5e": TokenMold.FOUNDRY_VERSION >= 10 ? "system.attributes.hp.formula" : "data.data.attributes.hp.formula",
-      "dcc": TokenMold.FOUNDRY_VERSION >= 10 ? "system.attributes.hitDice.value" : "data.data.attributes.hitDice.value"
-    }
+      dnd5e: "system.attributes.hp.formula",
+      dcc: "system.attributes.hitDice.value",
+    };
 
     const formula = getProperty(actor, hpProperties[TokenMold.GAME_SYSTEM]);
     if (formula) {
       const r = new Roll(formula.replace(" ", ""));
-      r.roll({async: false});
-      if (this.data.hp.toChat)
+      r.roll({ async: false });
+      if (this.data.hp.toChat) {
         r.toMessage({
           rollMode: "gmroll",
           flavor: data.name + " rolls for hp!",
         });
+      }
       // Make sure hp is at least 1
       const val = Math.max(r.total, 1);
 
-      setProperty(newData, TokenMold.FOUNDRY_VERSION >= 11 ? "delta.system.attributes.hp.value" : TokenMold.FOUNDRY_VERSION >= 10 ? "actorData.system.attributes.hp.value" : "actorData.data.attributes.hp.value", val);
-      setProperty(newData, TokenMold.FOUNDRY_VERSION >= 11 ? "delta.system.attributes.hp.max" : TokenMold.FOUNDRY_VERSION >= 10 ? "actorData.system.attributes.hp.max" : "actorData.data.attributes.hp.max", val);
-    } else
+      setProperty(newData, "delta.system.attributes.hp.value", val);
+      setProperty(newData, "delta.system.attributes.hp.max", val);
+    } else {
       ui.notifications.warn("Can not randomize hp. HP formula is not set.");
+    }
     return;
   }
 
   _modifyName(newData, data, actor, sceneId) {
-    let name = TokenMold.FOUNDRY_VERSION >= 10 ? actor.prototypeToken.name : actor.data.token.name;
+    let name = actor.prototypeToken.name;
 
-    if (["remove", "replace"].includes(this.data.name.replace) && !(this.data.name.baseNameOverride && event.getModifierState("Shift"))) {
+    if (
+      ["remove", "replace"].includes(this.data.name.replace) &&
+      !(this.data.name.baseNameOverride && event.getModifierState("Shift"))
+    ) {
       name = "";
     }
 
@@ -410,20 +446,22 @@ export default class TokenMold {
     if (this.data.name.number.use) {
       let number = 0;
       // Check if number in session database
-      if (this.counter[sceneId][data.actorId] !== undefined)
+      if (this.counter[sceneId][data.actorId] !== undefined) {
         number = this.counter[sceneId][data.actorId];
-      else {
+      } else {
         // Extract number from last created token with the same actor ID
-        const sameTokens = (TokenMold.FOUNDRY_VERSION >= 10 ? 
-          game.scenes.get(sceneId).tokens.filter((e) => e.actorId === data.actorId) : 
-          game.scenes.get(sceneId).data.tokens.filter((e) => e.actorId === data.actorId)) || [];
+        const sameTokens =
+          game.scenes
+            .get(sceneId)
+            .tokens.filter((e) => e.actorId === data.actorId) || [];
         if (sameTokens.length !== 0) {
           const lastTokenName = sameTokens[sameTokens.length - 1].name;
           // Split by prefix and take last element
           let tmp = lastTokenName.split(this.data.name.number.prefix).pop();
-          if (tmp !== "")
+          if (tmp !== "") {
             // Split by suffix and take first element
             number = tmp.split(this.data.name.number.suffix)[0];
+          }
         }
       }
       // Convert String back to number
@@ -442,12 +480,15 @@ export default class TokenMold {
           break;
       }
       // If result is no number, set to zero
-      if (isNaN(number)) number = 0;
-      else {
+      if (isNaN(number)) {
+        number = 0;
+      } else {
         // count upwards
-        if (this.data.name.number.range > 1)
+        if (this.data.name.number.range > 1) {
           number += Math.ceil(Math.random() * this.data.name.number.range);
-        else number++;
+        } else {
+          number++;
+        }
       }
 
       switch (this.data.name.number.type) {
@@ -468,18 +509,21 @@ export default class TokenMold {
         this.data.name.number.prefix + number + this.data.name.number.suffix;
     }
 
-    if (this.data.name.replace === "replace")
+    if (this.data.name.replace === "replace") {
       name = this._pickNewName(actor) + " " + name;
+    }
 
     if (this.data.name.prefix.use) {
       const adj =
         this.adjectives.results._source[
           Math.floor(this.adjectives.results.size * Math.random())
         ].text;
-      if (this.data.name.prefix.position === "back") name = name + " " + adj;
-      else name = adj + " " + name;
+      if (this.data.name.prefix.position === "back") {
+        name = name + " " + adj;
+      } else {
+        name = adj + " " + name;
+      }
     }
-    // name = this.adjectives[Math.floor(Math.random() * this.adjectives.length)] + " " + name;
 
     name += numberSuffix;
 
@@ -524,14 +568,20 @@ export default class TokenMold {
     let lang;
     for (let attribute of attributes) {
       const langs = attribute.languages;
-      const val = TokenMold.FOUNDRY_VERSION >= 10 ? String(getProperty(actor.system, attribute.attribute)).toLowerCase() : String(getProperty(actor.data, attribute.attribute)).toLowerCase();
+      const val = String(
+        getProperty(actor.system, attribute.attribute),
+      ).toLowerCase();
 
       lang = langs[val];
 
-      if (lang !== undefined) break;
+      if (lang !== undefined) {
+        break;
+      }
     }
 
-    if (lang === undefined) lang = this.data.name.options.default;
+    if (lang === undefined) {
+      lang = this.data.name.options.default;
+    }
 
     if (lang === "random") {
       const keys = Object.keys(this.dict);
@@ -552,8 +602,12 @@ export default class TokenMold {
       const c2 = newName.slice(-1);
       const br = i == nameLength ? this.dict[lang].end : this.dict[lang].mid;
       const c3 = ltrs(c1, c2, br) || ltrs(c1, c2, this.dict[lang].all) || {};
-      if (c1 == c2 && c1 in c3) delete c3[c1];
-      if (Object.keys(c3).length == 0) break;
+      if (c1 == c2 && c1 in c3) {
+        delete c3[c1];
+      }
+      if (Object.keys(c3).length == 0) {
+        break;
+      }
       newName = newName + this._chooseWeighted(c3);
     }
 
@@ -562,20 +616,24 @@ export default class TokenMold {
       this._chgCase(
         newName.slice(1),
         this.dict[lang].upper,
-        this.dict[lang].lower
+        this.dict[lang].lower,
       );
     return newName;
   }
 
   _dealphabetize(num, letterStyle) {
-    if (num === "0") return 0;
+    if (num === "0") {
+      return 0;
+    }
     let ret = 0;
     const startValue = {
       upper: 64,
       lower: 96,
     }[letterStyle];
 
-    for (const char of num) ret += char.charCodeAt(0) - startValue;
+    for (const char of num) {
+      ret += char.charCodeAt(0) - startValue;
+    }
 
     return ret;
   }
@@ -600,7 +658,9 @@ export default class TokenMold {
 
   // Romanizes a number, code is from : http://blog.stevenlevithan.com/archives/javascript-roman-numeral-converter
   _romanize(num) {
-    if (!+num) return false;
+    if (!+num) {
+      return false;
+    }
     var digits = String(+num).split(""),
       key = [
         "",
@@ -636,13 +696,17 @@ export default class TokenMold {
       ],
       roman = "",
       i = 3;
-    while (i--) roman = (key[+digits.pop() + i * 10] || "") + roman;
+    while (i--) {
+      roman = (key[+digits.pop() + i * 10] || "") + roman;
+    }
     return Array(+digits.join("") + 1).join("M") + roman;
   }
 
   // code is from : http://blog.stevenlevithan.com/archives/javascript-roman-numeral-converter
   _deromanize(rom) {
-    if (typeof rom !== "string") return 0;
+    if (typeof rom !== "string") {
+      return 0;
+    }
     let str = rom.toUpperCase(),
       validator = /^M*(?:D?C{0,3}|C[MD])(?:L?X{0,3}|X[CL])(?:V?I{0,3}|I[XV])$/,
       token = /[MDLV]|C[MD]?|X[CL]?|I[XV]?/g,
@@ -663,8 +727,12 @@ export default class TokenMold {
       },
       num = 0,
       m;
-    if (!(str && validator.test(str))) return false;
-    while ((m = token.exec(str))) num += key[m[0]];
+    if (!(str && validator.test(str))) {
+      return false;
+    }
+    while ((m = token.exec(str))) {
+      num += key[m[0]];
+    }
     return num;
   }
 
@@ -679,11 +747,13 @@ export default class TokenMold {
       huge: 3,
       grg: 4,
     };
-    const aSize = TokenMold.FOUNDRY_VERSION >= 10 ? actor.system.traits.size : actor.data.data.traits.size;
+    const aSize = actor.system.traits.size;
     let tSize = sizes[aSize];
 
     // if size could not be found return
-    if (tSize === undefined) return;
+    if (tSize === undefined) {
+      return;
+    }
 
     const scene = game.scenes.get(sceneId);
 
@@ -691,20 +761,13 @@ export default class TokenMold {
     //  5 ft => normal size
     // 10 ft => double
     // etc.
-    if (TokenMold.FOUNDRY_VERSION >= 10) {
-      if (scene.grid.type && /(ft)|eet/.exec(scene.grid.units) !== null)
+    if (scene.grid.type && /(ft)|eet/.exec(scene.grid.units) !== null) {
       tSize *= 5 / scene.grid.distance;
-    } else {
-      if (scene.data.gridType && /(ft)|eet/.exec(scene.data.gridUnits) !== null)
-      tSize *= 5 / scene.data.gridDistance;
     }
 
     if (tSize < 1) {
-      if (TokenMold.FOUNDRY_VERSION >= 10) {
-        newData["texture.scaleX"] = newData["texture.scaleY"] = tSize < 0.2 ? 0.2 : Math.floor(tSize * 10)/10;
-      } else {
-        newData["scale"] = tSize < 0.2 ? 0.2 : Math.floor(tSize * 10)/10;
-      }
+      newData["texture.scaleX"] = newData["texture.scaleY"] =
+        tSize < 0.2 ? 0.2 : Math.floor(tSize * 10) / 10;
       newData["width"] = newData["height"] = 1;
     } else {
       const int = Math.floor(tSize);
@@ -712,14 +775,8 @@ export default class TokenMold {
       // Make sure to only have integers
       newData["width"] = newData["height"] = int;
       // And scale accordingly
-      if (TokenMold.FOUNDRY_VERSION >= 10) {
-        tSize = Math.max((tSize / int), 0.2);
-        newData["texture.scaleX"] = newData["texture.scaleY"] = tSize;
-      } else {
-        newData["scale"] = tSize / int;
-        // Set minimum scale 0.25
-        newData["scale"] = Math.max(newData["scale"], 0.25);
-      }
+      tSize = Math.max(tSize / int, 0.2);
+      newData["texture.scaleX"] = newData["texture.scaleY"] = tSize;
     }
   }
 
@@ -845,13 +902,15 @@ export default class TokenMold {
     if (
       getProperty(this.data, "overlay.attrs") &&
       this.data.overlay.attrs.length === 0
-    )
+    ) {
       delete this.data.overlay.attrs;
+    }
     if (
       getProperty(this.data, "name.options.attributes") &&
       this.data.name.options.attributes.length === 0
-    )
+    ) {
       delete this.data.name.options.attributes;
+    }
     this.data = mergeObject(this.defaultSettings(), this.data);
 
     if (/dnd5e|sw5e/.exec(TokenMold.GAME_SYSTEM) !== null) {
@@ -862,7 +921,12 @@ export default class TokenMold {
       }
     }
     this._loadDicts();
-    TokenMold.log(false, TokenMold.LOG_LEVEL.Debug, "Loading Settings", this.data);
+    TokenMold.log(
+      false,
+      TokenMold.LOG_LEVEL.Debug,
+      "Loading Settings",
+      this.data,
+    );
   }
 
   get dndDefaultNameOptions() {
@@ -880,7 +944,7 @@ export default class TokenMold {
         },
         // Uncomment this section if races get implemented in FVTT
         // {
-        //     attribute: TokenMold.FOUNDRY_VERSION >= 10 ? "system.details.race" :"data.details.race",
+        //     attribute: "system.details.race",
         //     languages: {
         //         "dragonborn": "norwegian",
         //         "dwarf": "welsh",
@@ -895,7 +959,7 @@ export default class TokenMold {
         // },
         // NPC Types
         {
-          attribute: TokenMold.FOUNDRY_VERSION >= 10 ? "system.details.type" : "data.details.type",
+          attribute: "system.details.type",
           languages: {
             humanoid: "irish",
             aberration: "icelandic",
@@ -921,22 +985,36 @@ export default class TokenMold {
     if (
       !this.adjectives ||
       this.adjectives.uuid !== this.data.name.prefix.table
-    )
+    ) {
       this._loadTable();
+    }
 
-    if (this.data.name.replace === "remove" && (!this.data.name.number.use && !this.data.name.prefix.use)) {
+    if (
+      this.data.name.replace === "remove" &&
+      !this.data.name.number.use &&
+      !this.data.name.prefix.use
+    ) {
       this.data.name.replace = "nothing";
-      TokenMold.log(true, TokenMold.LOG_LEVEL.Warn, game.i18n.localize("tmold.warn.removeName"));
-      ui.notifications.warn(game.i18n.localize("tmold.warn.removeName"))
+      TokenMold.log(
+        true,
+        TokenMold.LOG_LEVEL.Warn,
+        game.i18n.localize("tmold.warn.removeName"),
+      );
+      ui.notifications.warn(game.i18n.localize("tmold.warn.removeName"));
     }
 
     await game.settings.set("Token-Mold", "everyone", this.data);
     this._loadDicts();
-    TokenMold.log(false, TokenMold.LOG_LEVEL.Debug, "Saving Settings", this.data);
+    TokenMold.log(
+      false,
+      TokenMold.LOG_LEVEL.Debug,
+      "Saving Settings",
+      this.data,
+    );
   }
 
   async _getBarAttributes() {
-    const types = TokenMold.FOUNDRY_VERSION >= 10 ? CONFIG.Actor.documentClass.TYPES : CONFIG.Actor.documentClass.metadata.types;
+    const types = CONFIG.Actor.documentClass.TYPES;
     let barData = { bar: {}, value: {} };
     let addElement = (obj, key, val) => {
       if (obj[key]) obj[key] += ", " + val;
@@ -944,10 +1022,12 @@ export default class TokenMold {
     };
     for (const type of types) {
       try {
-        const docClass = TokenMold.FOUNDRY_VERSION >= 10 ? 
-        new CONFIG.Actor.documentClass({ type: type, name: "tmp"}).system :
-        new CONFIG.Actor.documentClass({ type: type, name: "tmp" }).data.data;
-        const { bar, value } = CONFIG.Token.documentClass.getTrackedAttributes(docClass);
+        const docClass = new CONFIG.Actor.documentClass({
+          type: type,
+          name: "tmp",
+        }).system;
+        const { bar, value } =
+          CONFIG.Token.documentClass.getTrackedAttributes(docClass);
         for (const val of bar) {
           addElement(barData.bar, val.join("."), type);
         }
@@ -955,7 +1035,13 @@ export default class TokenMold {
           addElement(barData.value, val.join("."), type);
         }
       } catch (e) {
-        TokenMold.log(false, TokenMold.LOG_LEVEL.Debug, "Error navigating document class type!", type, e);
+        TokenMold.log(
+          false,
+          TokenMold.LOG_LEVEL.Debug,
+          "Error navigating document class type!",
+          type,
+          e,
+        );
       }
     }
     return barData;
@@ -1003,11 +1089,12 @@ class TokenMoldForm extends FormApplication {
       const el = $(e);
       const icon = el.find(".icon").val(),
         value = el.find(".value").val();
-      if (icon !== "" && value !== "")
+      if (icon !== "" && value !== "") {
         attrs.push({
           icon: icon,
           path: value,
         });
+      }
     });
     this.data.overlay.attrs = attrs;
 
@@ -1035,8 +1122,12 @@ class TokenMoldForm extends FormApplication {
   async _updateObject(event, formData) {
     let min = formData["name.options.min"],
       max = formData["name.options.max"];
-    if (min < 0) min = 0;
-    if (max < 0) max = 0;
+    if (min < 0) {
+      min = 0;
+    }
+    if (max < 0) {
+      max = 0;
+    }
 
     if (min > max) {
       const tmp = min;
@@ -1049,14 +1140,18 @@ class TokenMoldForm extends FormApplication {
     // For name prefix and suffix, if the value is only a space the formData doesn't pick it up, so check and manually set prior to merge.
     let prefix = $(this.form).find("input[name='name.number.prefix']").val();
     let suffix = $(this.form).find("input[name='name.number.suffix']").val();
-    formData["name.number.prefix"] = formData["name.number.prefix"] !== prefix ? prefix : formData["name.number.prefix"];
-    formData["name.number.suffix"] = formData["name.number.suffix"] !== suffix ? suffix : formData["name.number.suffix"];
+    formData["name.number.prefix"] =
+      formData["name.number.prefix"] !== prefix
+        ? prefix
+        : formData["name.number.prefix"];
+    formData["name.number.suffix"] =
+      formData["name.number.suffix"] !== suffix
+        ? suffix
+        : formData["name.number.suffix"];
 
     this.object.data = mergeObject(this.data, formData);
 
     if (this._resetOptions === true) {
-      // this.object.data.name.options = this.object.dndDefaultNameOptions;
-
       const dndOptions = this.object.dndDefaultNameOptions;
       this.object.data.name.options.default = dndOptions.default;
       this.object.data.name.options.attributes = dndOptions.attributes;
@@ -1082,14 +1177,19 @@ class TokenMoldForm extends FormApplication {
     data.displayModes = CONST.TOKEN_DISPLAY_MODES;
     data.dispositions = CONST.TOKEN_DISPOSITIONS;
     data.defaultIcons = this.defaultIcons;
-    data.showCreatureSize = /dnd5e|pf2e/.exec(game.data.system.id) !== null
-    data.showHP = /dnd5e|dcc|sw5e/.exec(game.data.system.id) !== null
+    data.showCreatureSize = /dnd5e|pf2e/.exec(game.data.system.id) !== null;
+    data.showHP = /dnd5e|dcc|sw5e/.exec(game.data.system.id) !== null;
     data.showSystem = this.object.systemSupported;
     data.languages = this.languages;
     data.rollTableList = this.object._rollTableList;
-    data.visionLabel = TokenMold.FOUNDRY_VERSION >= 10 ? game.i18n.localize("TOKEN.VisionEnabled") : game.i18n.localize("TOKEN.VisionHas");
-    data.isV9 = !(TokenMold.FOUNDRY_VERSION >= 10);
-    TokenMold.log(false, TokenMold.LOG_LEVEL.Debug, "Prepared data", data, this._rollTableList);
+    data.visionLabel = game.i18n.localize("TOKEN.VisionEnabled");
+    TokenMold.log(
+      false,
+      TokenMold.LOG_LEVEL.Debug,
+      "Prepared data",
+      data,
+      this._rollTableList,
+    );
     return data;
   }
 
@@ -1097,23 +1197,24 @@ class TokenMoldForm extends FormApplication {
     if (/dnd5e|sw5e/.exec(game.data.system.id) !== null) {
       return [
         {
-          value: TokenMold.FOUNDRY_VERSION >= 10 ? "system.attributes.ac.value" : "data.attributes.ac.value",
+          value: "system.attributes.ac.value",
           label: "Armor Class",
           icon: '<i class="fas fa-eye"></i>',
         },
         {
-          value: TokenMold.FOUNDRY_VERSION >= 10 ? "system.skills.prc.passive" : "data.skills.prc.passive",
+          value: "system.skills.prc.passive",
           label: "Passive Perception",
           icon: '<i class="fas fa-shield-alt"></i>',
         },
       ];
-    } else
+    } else {
       return [
         {
           icon: '<i class="fas fa-eye"></i>',
           value: "",
         },
       ];
+    }
   }
 
   get defaultIcons() {
@@ -1167,24 +1268,27 @@ class TokenMoldForm extends FormApplication {
       if (
         container.prev('.form-group:not(".header")').length > 0 ||
         container.next(".form-group").length > 0
-      )
+      ) {
         container.remove();
+      }
     });
 
     html.find(".overlay").on("change keyup", "input.icon", (ev) => {
       ev.target.parentNode.parentNode.getElementsByClassName(
-        "prev"
+        "prev",
       )[0].innerHTML = "17&nbsp;" + ev.target.value;
     });
 
     html.find(".name-replace").on("change", (ev) => {
       const nameRandomizer =
         ev.currentTarget.parentNode.parentNode.querySelector(
-          ".name-randomizer-options"
+          ".name-randomizer-options",
         );
-      if (ev.currentTarget.value === "replace")
+      if (ev.currentTarget.value === "replace") {
         nameRandomizer.style.display = "block";
-      else nameRandomizer.style.display = "none";
+      } else {
+        nameRandomizer.style.display = "none";
+      }
     });
     html.find(".name-replace").change();
 
@@ -1217,9 +1321,9 @@ class TokenMoldForm extends FormApplication {
 
       let prev = container.prev(".form-group");
       // only delete if not last element
-      if (prev.length > 0 || container.next(".form-group").length > 0)
+      if (prev.length > 0 || container.next(".form-group").length > 0) {
         container.remove();
-      else {
+      } else {
         // alternatively delete whole attribute
         const parentContainer = container.closest(".attribute-group");
         if (
@@ -1234,7 +1338,6 @@ class TokenMoldForm extends FormApplication {
     if (game.system.id === "dnd5e") {
       const resetBtn = html.find(".reset");
       resetBtn[0].innerHTML = '<i class="fas fa-undo"></i>';
-      let resetLangs = (ev) => {};
       resetBtn.on("click", (ev) => {
         this._resetOptions = true;
         this._onSubmit(ev);
@@ -1262,8 +1365,11 @@ class TokenMoldForm extends FormApplication {
       this.object.counter[sceneId] = {};
       const tokens = canvas.scene.getEmbeddedCollection("Token");
 
-      for (const token of tokens)
-        if (token.actorId) this.object.counter[sceneId][token.actorId] = 0;
+      for (const token of tokens) {
+        if (token.actorId) {
+          this.object.counter[sceneId][token.actorId] = 0;
+        }
+      }
 
       ui.notifications.notify("Finished resetting counters");
     });
@@ -1285,9 +1391,14 @@ class TokenMoldForm extends FormApplication {
     };
 
     let barAttributes = [];
-    for (let type in game.system.model.Actor) {
-      let newAttributes = getAttributes(game.system.model.Actor[type]).map(
-        (e) => e.join(".")
+
+    const types = Actor.implementation.TYPES;
+    const shellMap = new Map(
+      types.map((t) => [t, new Actor.implementation({ name: t, type: t })]),
+    );
+    shellMap.forEach((value, key, map) => {
+      const newAttributes = getAttributes(value.toObject().system).map((e) =>
+        e.join("."),
       );
       // find duplicates
       for (let attr of newAttributes) {
@@ -1295,20 +1406,22 @@ class TokenMoldForm extends FormApplication {
         let duplicate = barAttributes.find((el) => el[1].includes(attr));
         // If not found,  add to attributes
         if (duplicate === undefined) {
-          barAttributes.push([type].concat(attr));
+          barAttributes.push([key].concat(attr));
         } else {
           // if found add actor type to list
-          duplicate[0] += ", " + type;
+          duplicate[0] += ", " + key;
         }
       }
-    }
+    });
     // Sort in groups by first element
     let groups = {};
     for (var attr of barAttributes) {
       const split = attr[1].split(".");
       const document = attr[0];
       const group = split[0];
-      if (groups[group] === undefined) groups[group] = [];
+      if (groups[group] === undefined) {
+        groups[group] = [];
+      }
       groups[group].push({
         document: document,
         attribute: split.splice(1).join("."),
@@ -1317,11 +1430,15 @@ class TokenMoldForm extends FormApplication {
     // also populate with some calculated data for dnd5e, that is not in the template.json
     if (/dnd5e|sw5e/.exec(game.data.system.id) !== null) {
       let sortFun = function (a, b) {
-        if (a.attribute > b.attribute) return 1;
-        else if (a.attribute < b.attribute) return -1;
+        if (a.attribute > b.attribute) {
+          return 1;
+        } else if (a.attribute < b.attribute) {
+          return -1;
+        }
         return 0;
       };
-      for (let skill of Object.keys(game.system.model.Actor["npc"].skills)) {
+      const npc = shellMap.get("npc");
+      for (let skill of Object.keys(npc.toObject().system.skills)) {
         groups["skills"].push({
           document: "character, npc",
           attribute: `${skill}.passive`,

--- a/templates/token-mold.html
+++ b/templates/token-mold.html
@@ -11,15 +11,15 @@
         <a class="item" data-tab="overlay" data-group='sections'>{{ localize "tmold.tab.statOverlay" }}</a>
     </nav>
     <div class='tab info' data-tab='Info' data-group='sections'>
-      <!-- <h2>General</h2> -->
-      <ul>
-        <li><a href="https://github.com/Moerill/token-mold#token-mold">{{ localize "tmold.info.featureOverview" }}</a></li>
-        <li><a href="https://github.com/Moerill/token-mold/issues">{{ localize "tmold.info.bugsOrSuggestions" }}</a></li>
-        <li><a href="https://github.com/Moerill/token-mold/blob/master/CHANGELOG.md">{{ localize "tmold.info.changelog" }}</a></li>
-      </ul>
-      
-      <h2 style="margin:0;"></h2>
-      <p class='token-mold-support'>{{ localize "tmold.info.support" }}&nbsp;<a href="https://github.com/Moerill/token-mold#support-the-development">{{ localize "tmold.info.clickHere" }}</a></p>
+        <!-- <h2>General</h2> -->
+        <ul>
+            <li><a href="https://github.com/Moerill/token-mold#token-mold">{{ localize "tmold.info.featureOverview" }}</a></li>
+            <li><a href="https://github.com/Moerill/token-mold/issues">{{ localize "tmold.info.bugsOrSuggestions" }}</a></li>
+            <li><a href="https://github.com/Moerill/token-mold/blob/master/CHANGELOG.md">{{ localize "tmold.info.changelog" }}</a></li>
+        </ul>
+
+        <h2 style="margin:0;"></h2>
+        <p class='token-mold-support'>{{ localize "tmold.info.support" }}&nbsp;<a href="https://github.com/Moerill/token-mold#support-the-development">{{ localize "tmold.info.clickHere" }}</a></p>
     </div>
     <div class="tab" data-tab="names" data-group='sections'>
         <div class="form-group">
@@ -27,24 +27,24 @@
         </div>
         <p>{{ localize "tmold.name.numberStyle" }}</p>
         <div class="form-group">
-            <input type='text' style='text-align:right' class='inp-small' value="{{data.name.number.prefix}}" title="{{ localize "tmold.name.prefix" }}" name="name.number.prefix" data-dtype="String">
+            <input type='text' style='text-align:right' class='inp-small' value="{{data.name.number.prefix}}" title="{{ localize " tmold.name.prefix" }}" name="name.number.prefix" data-dtype="String">
             <select class='number-type' name="name.number.type" data-dtype="String">
                 {{#select data.name.number.type}}
                 {{#each numberStyles as |label key|}}
-                    <option value="{{key}}">{{label}}</option>
+                <option value="{{key}}">{{label}}</option>
                 {{/each}}
                 {{/select}}
             </select>
-            <input type='text' class='inp-small' value="{{data.name.number.suffix}}" title="{{ localize "tmold.name.suffix" }}" name="name.number.suffix" data-dtype="String">
+            <input type='text' class='inp-small' value="{{data.name.number.suffix}}" title="{{ localize " tmold.name.suffix" }}" name="name.number.suffix" data-dtype="String">
         </div>
-        <div class="form-group" title="{{ localize "tmold.name.increaseIndexHelp" }}">
-            <label>{{ localize "tmold.name.increaseIndex" }}&nbsp;</label><input type="text" data-dtype="Number" name="name.number.range" value="{{#if data.name.number.range}}{{data.name.number.range}}{{else}}1{{/if}}"/>
+        <div class="form-group" title="{{ localize " tmold.name.increaseIndexHelp" }}">
+            <label>{{ localize "tmold.name.increaseIndex" }}&nbsp;</label><input type="text" data-dtype="Number" name="name.number.range" value="{{#if data.name.number.range}}{{data.name.number.range}}{{else}}1{{/if}}" />
         </div>
         <div class="form-group">
             <a class='reset-counter' title='{{ localize "tmold.name.resetCounterHelp" }}'><i class="fas fa-undo"></i>&nbsp;{{ localize "tmold.name.resetCounter" }}</a>
         </div>
         <div class="form-group">
-            <input type='checkbox' name='name.prefix.use' id='use_prefix'  data-dtype="Boolean" {{checked data.name.prefix.use}}><label for='use_prefix'>{{ localize "tmold.name.addAdjective" }}</label>
+            <input type='checkbox' name='name.prefix.use' id='use_prefix' data-dtype="Boolean" {{checked data.name.prefix.use}}><label for='use_prefix'>{{ localize "tmold.name.addAdjective" }}</label>
         </div>
 
         <div class="form-group">
@@ -52,11 +52,11 @@
             <select name="name.prefix.table" data-dtype="String">
                 {{#select data.name.prefix.table}}
                 {{#each rollTableList as |array group|}}
-                    <optgroup label="{{group}}">
-                        {{#each array}}
-                        <option value="{{this.uuid}}">{{this.name}}</option>
-                        {{/each}}
-                    </optgroup>
+                <optgroup label="{{group}}">
+                    {{#each array}}
+                    <option value="{{this.uuid}}">{{this.name}}</option>
+                    {{/each}}
+                </optgroup>
                 {{/each}}
                 {{/select}}
             </select>
@@ -75,8 +75,8 @@
             <select class='name-replace' name='name.replace' data-dtype="String">
                 {{#select data.name.replace}}
                 <option value="nothing">{{ localize "tmold.name.baseNameNothing" }}</option>
-                    <option value="remove">{{ localize "tmold.name.baseNameRemove" }}</option>
-                    <option value="replace">{{ localize "tmold.name.baseNameReplace" }}</option>
+                <option value="remove">{{ localize "tmold.name.baseNameRemove" }}</option>
+                <option value="replace">{{ localize "tmold.name.baseNameReplace" }}</option>
                 {{/select}}
             </select>
         </div>
@@ -84,7 +84,7 @@
             <input type='checkbox' name='name.baseNameOverride' id='baseNameOverride' {{checked data.name.baseNameOverride}} data-dtype="Boolean"><label for='baseNameOverride'>{{ localize "tmold.name.baseNameOverride" }}</label>
         </div>
         <div class="form-group name-randomizer-options">
-            <span title="{{ localize "tmold.name.replaceHelp" }}">
+            <span title="{{ localize " tmold.name.replaceHelp" }}">
                 {{ localize "tmold.name.replaceInfo1" }}<br>{{ localize "tmold.name.replaceInfo2" }}<br><em>{{ localize "tmold.name.replaceInfo3" }}</em>
             </span>
 
@@ -93,11 +93,11 @@
                 <div class="flexrow">
                     <section>
                         <label>{{ localize "tmold.name.minimum" }}</label>
-                        <input type='text' name='name.options.min' value='{{data.name.options.min}}' data-dtype='Number'/>
+                        <input type='text' name='name.options.min' value='{{data.name.options.min}}' data-dtype='Number' />
                     </section>
                     <section>
                         <label>{{ localize "tmold.name.maximum" }}</label>
-                        <input type='text' name='name.options.max' value='{{data.name.options.max}}' data-dtype='Number'/>
+                        <input type='text' name='name.options.max' value='{{data.name.options.max}}' data-dtype='Number' />
                     </section>
                 </div>
             </div>
@@ -108,7 +108,7 @@
                 <h4 class='attribute'>{{ localize "tmold.name.attribute" }}</h4>
                 <h4 class='value'>{{ localize "tmold.name.value" }}</h4>
                 <h4 class='language'>{{ localize "tmold.name.language" }}</h4>
-                <a class='reset' title="{{ localize "tmold.name.reset" }}"></a>
+                <a class='reset' title="{{ localize " tmold.name.reset" }}"></a>
             </div>
             <div class="form-group language-selection language-group default-group">
                 <span class='attribute default' value='default'>{{ localize "tmold.name.default" }}</span>
@@ -117,11 +117,11 @@
                     {{#select data.name.options.default}}
                     <option value="random">{{ localize "tmold.name.random" }}</option>
                     {{#each @root.languages}}
-                        <option value="{{this}}">{{this}}</option>
+                    <option value="{{this}}">{{this}}</option>
                     {{/each}}
                     {{/select}}
                 </select>
-                <a class='remove' title="{{ localize "tmold.name.delete" }}"></a>
+                <a class='remove' title="{{ localize " tmold.name.delete" }}"></a>
             </div>
             {{#each data.name.options.attributes as |attrs idx|}}
             <div class="form-group attribute-selection attribute-group">
@@ -129,7 +129,7 @@
                     {{#select this.attribute}}
                     <option value="">{{ localize "tmold.stat.none" }}</option>
                     <option value="name">{{ localize "tmold.stat.name" }}</option>
-                    {{#each @root.actorAttributes as |v  k|}}
+                    {{#each @root.actorAttributes as |v k|}}
                     <optgroup label="{{k}}">
                         {{#each v}}
                         <option value="data.{{k}}.{{this.attribute}}">{{this.attribute}} [{{this.document}}]</option>
@@ -141,23 +141,23 @@
                 <div class=' language-selection '>
                     {{#each this.languages as |lang attr|}}
                     <div class="form-group language-group">
-                        <input type='text' class='value' value='{{attr}}'/>
+                        <input type='text' class='value' value='{{attr}}' />
                         <select class='language'>
                             {{#select lang}}
                             <option value="random">{{ localize "tmold.name.random" }}</option>
                             {{#each @root.languages}}
-                                <option value="{{this}}">{{this}}</option>
+                            <option value="{{this}}">{{this}}</option>
                             {{/each}}
                             {{/select}}
                         </select>
-                        <a class='lang-remove' title="{{ localize "tmold.name.delete" }}"><i class="fas fa-times"></i></a>
+                        <a class='lang-remove' title="{{ localize " tmold.name.delete" }}"><i class="fas fa-times"></i></a>
                     </div>
                     {{/each}}
-                <a class='add-language-value'><i class="fas fa-plus"></i>&nbsp;{{ localize "tmold.name.addValue" }}</a>
+                    <a class='add-language-value'><i class="fas fa-plus"></i>&nbsp;{{ localize "tmold.name.addValue" }}</a>
                 </div>
             </div>
             {{/each}}
-        <a class='add-language-attribute'><i class="fas fa-plus"></i>&nbsp;{{ localize "tmold.name.addAttribute" }}</a>
+            <a class='add-language-attribute'><i class="fas fa-plus"></i>&nbsp;{{ localize "tmold.name.addAttribute" }}</a>
         </div>
     </div>
     <div class="tab" data-tab="hp" data-group='sections'>
@@ -167,8 +167,8 @@
         </div>
         {{/if}}
         {{#if showCreatureSize}}
-        <div class="form-group" title="{{ localize "tmold.system.setTokenSizeHelp" }}">
-            <input data-dtype="Boolean" type='checkbox' name='size.use' id='sizeUse' {{checked data.size.use}}/><label for='sizeUse'>{{ localize "tmold.system.setTokenSize" }}</label>
+        <div class="form-group" title="{{ localize " tmold.system.setTokenSizeHelp" }}">
+            <input data-dtype="Boolean" type='checkbox' name='size.use' id='sizeUse' {{checked data.size.use}} /><label for='sizeUse'>{{ localize "tmold.system.setTokenSize" }}</label>
         </div>
         {{/if}}
     </div>
@@ -178,12 +178,12 @@
             <label>{{ localize "TOKEN.ResourceDisplay" }}: </label>
             <div class="flexcol">
                 <section>
-                <input type='checkbox' name='config.displayBars.use' id='displayBarsUse' {{checked data.config.displayBars.use}}><label for='displayBarsUse'>{{ localize "tmold.default.overwrite" }}</label>
+                    <input type='checkbox' name='config.displayBars.use' id='displayBarsUse' {{checked data.config.displayBars.use}}><label for='displayBarsUse'>{{ localize "tmold.default.overwrite" }}</label>
                 </section>
                 <select name="config.displayBars.value" data-dtype="Number">
                     {{#select data.config.displayBars.value}}
                     {{#each displayModes as |label key|}}
-                        <option value="{{label}}">{{key}}</option>
+                    <option value="{{label}}">{{key}}</option>
                     {{/each}}
                     {{/select}}
                 </select>
@@ -193,18 +193,18 @@
             <label>{{ localize "TOKEN.ResourceBar1A" }}: </label>
             <div class="flexcol">
                 <section>
-                <input type='checkbox' name='config.bar1.use' id='bar1Use' {{checked data.config.bar1.use}}><label for='bar1Use'>{{ localize "tmold.default.overwrite" }}</label>
+                    <input type='checkbox' name='config.bar1.use' id='bar1Use' {{checked data.config.bar1.use}}><label for='bar1Use'>{{ localize "tmold.default.overwrite" }}</label>
                 </section>
                 <select name="config.bar1.attribute" data-dtype="String">
                     {{#select data.config.bar1.attribute}}
-                        <option value="">None</option>
-                        {{#each barAttributes as |attrs label|}}
-                            <optgroup label="{{label}}">
-                                {{#each attrs as |types attr|}}
-                                    <option value="{{attr}}">{{attr}} [{{types}}]</option>
-                                {{/each}}
-                            </optgroup>
+                    <option value="">None</option>
+                    {{#each barAttributes as |attrs label|}}
+                    <optgroup label="{{label}}">
+                        {{#each attrs as |types attr|}}
+                        <option value="{{attr}}">{{attr}} [{{types}}]</option>
                         {{/each}}
+                    </optgroup>
+                    {{/each}}
                     {{/select}}
                 </select>
             </div>
@@ -213,18 +213,18 @@
             <label>{{ localize "TOKEN.ResourceBar2A" }}: </label>
             <div class="flexcol">
                 <section>
-                <input type='checkbox' name='config.bar2.use' id='bar2' {{checked data.config.bar2.use}}><label for='bar2Use'>{{ localize "tmold.default.overwrite" }}</label>
+                    <input type='checkbox' name='config.bar2.use' id='bar2' {{checked data.config.bar2.use}}><label for='bar2Use'>{{ localize "tmold.default.overwrite" }}</label>
                 </section>
                 <select name="config.bar2.attribute" data-dtype="String">
                     {{#select data.config.bar2.attribute}}
-                        <option value="">None</option>
-                        {{#each barAttributes as |attrs label|}}
-                            <optgroup label="{{label}}">
-                                {{#each attrs as |types attr|}}
-                                    <option value="{{attr}}">{{attr}} [{{types}}]</option>
-                                {{/each}}
-                            </optgroup>
+                    <option value="">None</option>
+                    {{#each barAttributes as |attrs label|}}
+                    <optgroup label="{{label}}">
+                        {{#each attrs as |types attr|}}
+                        <option value="{{attr}}">{{attr}} [{{types}}]</option>
                         {{/each}}
+                    </optgroup>
+                    {{/each}}
                     {{/select}}
                 </select>
             </div>
@@ -233,12 +233,12 @@
             <label>{{ localize "TOKEN.CharShowNameplate"}}: </label>
             <div class="flexcol">
                 <section>
-                <input type='checkbox' name='config.displayName.use' id='displayNameUse' {{checked data.config.displayName.use}}><label for='displayNameUse'>{{ localize "tmold.default.overwrite" }}</label>
+                    <input type='checkbox' name='config.displayName.use' id='displayNameUse' {{checked data.config.displayName.use}}><label for='displayNameUse'>{{ localize "tmold.default.overwrite" }}</label>
                 </section>
                 <select name="config.displayName.value" data-dtype="Number">
                     {{#select data.config.displayName.value}}
                     {{#each displayModes as |label key|}}
-                        <option value="{{label}}">{{key}}</option>
+                    <option value="{{label}}">{{key}}</option>
                     {{/each}}
                     {{/select}}
                 </select>
@@ -247,8 +247,8 @@
         <div class="form-group">
             <label>
                 {{ localize "TOKEN.Disposition"}}:</label>
-                <div class="flexcol">
-                    <section>
+            <div class="flexcol">
+                <section>
                     <input type='checkbox' name='config.disposition.use' id='dispositionUse' {{checked data.config.disposition.use}}><label for='dispositionUse'>{{ localize "tmold.default.overwrite" }}</label>
                 </section>
                 <select name="config.disposition.value" data-dtype="Number">
@@ -258,13 +258,13 @@
                     {{/each}}
                     {{/select}}
                 </select>
-</div>
             </div>
+        </div>
         <div class="form-group">
             <label>{{ localize "tmold.default.vision" }}</label>
             <div class="flexcol">
                 <section>
-                <input type='checkbox' name='config.vision.use' {{checked data.config.vision.use}}><label for='vision'>{{ localize "tmold.default.overwrite" }}</label>
+                    <input type='checkbox' name='config.vision.use' {{checked data.config.vision.use}}><label for='vision'>{{ localize "tmold.default.overwrite" }}</label>
                 </section>
                 <section>
                     <input type='checkbox' name='config.vision.value' {{checked data.config.vision.value}}><label for='vision'>{{visionLabel}}</label>
@@ -275,7 +275,7 @@
             <label>{{ localize "tmold.default.randScale" }}</label>
             <div class="flexcol">
                 <section>
-                <input type='checkbox' name='config.scale.use' id='scaleUse' {{checked data.config.scale.use}}><label for='scaleUse'>{{ localize "tmold.default.active" }}</label>
+                    <input type='checkbox' name='config.scale.use' id='scaleUse' {{checked data.config.scale.use}}><label for='scaleUse'>{{ localize "tmold.default.active" }}</label>
                 </section>
                 <section>
                     {{ localize "tmold.default.min" }}
@@ -291,7 +291,7 @@
             <label>{{ localize "tmold.default.randRotation" }}</label>
             <div class="flexcol">
                 <section>
-                <input type='checkbox' name='config.rotation.use' id='rotationUse' {{checked data.config.rotation.use}}><label for='rotationUse'>{{ localize "tmold.default.overwrite" }}</label>
+                    <input type='checkbox' name='config.rotation.use' id='rotationUse' {{checked data.config.rotation.use}}><label for='rotationUse'>{{ localize "tmold.default.overwrite" }}</label>
                 </section>
                 <section>
                     {{ localize "tmold.default.minAngle" }}
@@ -317,7 +317,7 @@
             </div>
         </div>
     </div>
-    <div class="tab overlay" data-tab="overlay" >
+    <div class="tab overlay" data-tab="overlay">
         <div class="form-group class unlinked">
             <input type='checkbox' name='enableOverlayForLinked' id='enableOverlayForLinked' {{checked data.enableOverlayForLinked}} data-dtype="Boolean">
             <label for='enableOverlayForLinked'>{{ localize "tmold.config.enableOverlayFor" }}&nbsp;<em>{{ localize "tmold.config.linkedTokens" }}</em>.</label>
@@ -328,7 +328,7 @@
         <div class="form-group attributes header">
             <h4 class='icon'>{{ localize "tmold.stat.attributeIcon" }}</h4>
             <h4 class='attribute'>{{ localize "tmold.stat.attribute" }}</h4>
-            <a class='remove' title="{{ localize "tmold.stat.attributeDelete" }}"></a>
+            <a class='remove' title="{{ localize " tmold.stat.attributeDelete" }}"></a>
         </div>
         {{#each data.overlay.attrs}}
         <div class="form-group attributes">
@@ -343,20 +343,16 @@
                 {{#select this.path}}
                 <option value="">{{ localize "tmold.stat.attributeNone" }}</option>
                 <option value="name">{{ localize "tmold.stat.attributeName" }}</option>
-                {{#each @root.actorAttributes as |v  k|}}
+                {{#each @root.actorAttributes as |v k|}}
                 <optgroup label="{{k}}">
                     {{#each v}}
-                    {{#if ../../isV9}}
-                    <option value="data.{{k}}.{{this.attribute}}">{{this.attribute}} [{{this.document}}]</option>
-                    {{else}}
                     <option value="system.{{k}}.{{this.attribute}}">{{this.attribute}} [{{this.document}}]</option>
-                    {{/if}}
                     {{/each}}
                 </optgroup>
                 {{/each}}
                 {{/select}}
             </select>
-            <a class='remove' title="{{ localize "tmold.stat.attributeDelete" }}"><i class="fas fa-times"></i></a>
+            <a class='remove' title="{{ localize " tmold.stat.attributeDelete" }}"><i class="fas fa-times"></i></a>
         </div>
         {{else}}
         <div class="form-group attributes">
@@ -368,21 +364,17 @@
             <select class='value' data-dtype='String'>
                 <option value="">{{ localize "tmold.stat.attributeNone" }}</option>
                 <option value="name">{{ localize "tmold.stat.attributeName" }}</option>
-                {{#each @root.actorAttributes as |v  k|}}
+                {{#each @root.actorAttributes as |v k|}}
                 <optgroup label="{{k}}">
                     {{#each v}}
-                    {{#if ../../isV9}}
-                    <option value="data.{{k}}.{{this.attribute}}">{{this.attribute}} [{{this.document}}]</option>
-                    {{else}}
                     <option value="system.{{k}}.{{this.attribute}}">{{this.attribute}} [{{this.document}}]</option>
-                    {{/if}}
                     {{/each}}
                 </optgroup>
                 {{/each}}
             </select>
-            <a class='remove' title="{{ localize "tmold.stat.attributeDelete" }}"><i class="fas fa-times"></i></a>
+            <a class='remove' title="{{ localize " tmold.stat.attributeDelete" }}"><i class="fas fa-times"></i></a>
         </div>
         {{/each}}
-    <a class='add-attribute'><i class="fas fa-plus"></i>&nbsp;{{ localize "tmold.stat.attributeAdd" }}</a>
+        <a class='add-attribute'><i class="fas fa-plus"></i>&nbsp;{{ localize "tmold.stat.attributeAdd" }}</a>
     </div>
 </form>


### PR DESCRIPTION
EDIT:
See here: https://github.com/Moerill/token-mold/pull/205

This PR pulls from my master branch which now has changes to allow me to publish from my fork. The linked PR is from the commit before those changes were added and is suitable to merge to Moerill:master.

Original:

ESLint/Prettier made a lot of extraneous changes. The important ones are:
* Remove V9 and V10 support
* Change actorAttributes to use new V11 system data model as described here: https://foundryvtt.com/article/active-effects/

fixes #202 
fixes #197 
fixes #186 
